### PR TITLE
Corrected ReadMe

### DIFF
--- a/packages/weather/README.md
+++ b/packages/weather/README.md
@@ -92,7 +92,7 @@ double kelvin = weather.temperature.kelvin;
 For API documentation on the forecast API, see the [OpenWeatherMap forecast API docs](https://openweathermap.org/forecast5).
 
 ```dart
-List<Weather> forecasts = await weatherStation.getFiveDayForecast();
+List<Weather> forecasts = await weatherStation.fiveDayForecast();
 ```
 
 ### Exceptions


### PR DESCRIPTION
The function getFiveDayForecast() is no longer using this name, instead it is defined as fiveDayForecast()