### PR TITLE
[Enhancement] Update Notifications Plugin to provide Package Message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,12 @@ GeneratedPluginRegistrant.m
 GeneratedPluginRegistrant.java
 build/
 .flutter-plugins
+
+### Eclipse Patch ###
+# Legacy Eclipse project files
+.project
+.classpath
+.settings
+
+# Annotation Processing
+.apt_generated

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -5,15 +5,18 @@
 A plugin for tracking notifications on the device. Works exclusively for Android.
 
 ## Installation
+
 Add ```notifications``` as a dependency in  `pubspec.yaml`.
 For help on adding as a dependency, view the [documentation](https://flutter.io/using-packages/).
 
 ## Usage
 
-### Android: Register service in the manifest 
-The plugin uses an Android system service to track notifications. 
-To allow this service to run the following code should be put inside the Android manifest, 
+### Android: Register service in the manifest
+
+The plugin uses an Android system service to track notifications.  
+To allow this service to run the following code should be put inside the Android manifest,
 between the `<application></application>` tags.
+
 ```xml
 <service android:name="cachet.plugins.notifications.NotificationListener"
     android:label="notifications"
@@ -25,9 +28,11 @@ between the `<application></application>` tags.
 ```
 
 ### Flutter: Listen to notification events
+
 All incoming data points are streamed with a `StreamSubscription` which is set up by calling the `listen()` method on the `notificationStream` stream object.
 
 Given a method `onData(NotificationEvent event)` the subscription can be set up as follows:
+
 ```dart
 Notifications _notifications;
 StreamSubscription _subscription;
@@ -48,14 +53,16 @@ void startListening() {
 
 To stop listening, call `cancel()` on the subcription object:
 
-```
+```dart
 void stopListening() {
   _subscription.cancel();
 }
 ```
+
 ### Notification Information
+
 Every time a notification is registered a `NotificationEvent` is received in Flutter, containing the following attributes:
+
 * `packageName [String]`: The name of the application which triggered the notification.
 * `timeStamp [DateTime]`: The timestamp at which the notification was received.
-    * Alternatively, `timeStamp` can be converted to a unix timestamp using `timeStamp.millisecondsSinceEpoch`.
-
+  * Alternatively, `timeStamp` can be converted to a unix timestamp using `timeStamp.millisecondsSinceEpoch`.

--- a/packages/notifications/android/src/main/java/cachet/plugins/notifications/NotificationListener.java
+++ b/packages/notifications/android/src/main/java/cachet/plugins/notifications/NotificationListener.java
@@ -1,6 +1,8 @@
 package cachet.plugins.notifications;
 
+import android.app.Notification;
 import android.content.Intent;
+import android.os.Bundle;
 import android.service.notification.NotificationListenerService;
 import android.service.notification.StatusBarNotification;
 
@@ -11,12 +13,19 @@ public class NotificationListener extends NotificationListenerService {
 
     public static String NOTIFICATION_INTENT = "notification_event";
     public static String NOTIFICATION_PACKAGE_NAME = "package_name";
+    public static String NOTIFICATION_PACKAGE_MESSAGE = "package_message";
 
     @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
+        // Retrieve package name to set as title.
         String packageName = sbn.getPackageName();
-        Intent intent = new  Intent(NOTIFICATION_INTENT);
+        // Retrieve extra object from notification to extract payload.
+        Bundle extras = sbn.getNotification().extras;
+        String packageMessage = extras.getCharSequence(Notification.EXTRA_TEXT).toString();
+        // Pass data from one activity to another.
+        Intent intent = new Intent(NOTIFICATION_INTENT);
         intent.putExtra(NOTIFICATION_PACKAGE_NAME, packageName);
+        intent.putExtra(NOTIFICATION_PACKAGE_MESSAGE, packageMessage);
         sendBroadcast(intent);
     }
 }

--- a/packages/notifications/android/src/main/java/cachet/plugins/notifications/NotificationsPlugin.java
+++ b/packages/notifications/android/src/main/java/cachet/plugins/notifications/NotificationsPlugin.java
@@ -1,5 +1,7 @@
 package cachet.plugins.notifications;
 
+import java.util.HashMap;
+
 /**
  * Flutter-specific
  */
@@ -104,7 +106,11 @@ public class NotificationsPlugin implements EventChannel.StreamHandler {
         @Override
         public void onReceive(Context context, Intent intent) {
             String packageName = intent.getStringExtra(NotificationListener.NOTIFICATION_PACKAGE_NAME);
-            eventSink.success(packageName);
+            String packageMessage = intent.getStringExtra(NotificationListener.NOTIFICATION_PACKAGE_MESSAGE);
+            HashMap<String, Object> map = new HashMap<>();
+            map.put("packageName",packageName);
+            map.put("packageMessage", packageMessage);
+            eventSink.success(map);
         }
     }
 }

--- a/packages/notifications/lib/notifications.dart
+++ b/packages/notifications/lib/notifications.dart
@@ -17,25 +17,28 @@ class NotificationException implements Exception {
 }
 
 class NotificationEvent {
-  String _packageName;
-  DateTime _timeStamp;
+  String packageMessage;
+  String packageName;
+  DateTime timeStamp;
 
-  NotificationEvent(this._packageName) {
-    _timeStamp = DateTime.now();
+  NotificationEvent({this.packageName, this.packageMessage, this.timeStamp});
+
+  factory NotificationEvent.fromMap(Map<dynamic, dynamic> map) {
+      DateTime time = DateTime.now();
+      String name = map['packageName'];
+      String message = map['packageMessage'];
+
+      return NotificationEvent(packageName: name, packageMessage: message, timeStamp: time);
   }
-
-  String get packageName => _packageName;
-
-  DateTime get timeStamp => _timeStamp;
 
   @override
   String toString() {
-    return "[$packageName sent notification @ $timeStamp";
+    return "Notification Event \n Package Name: $packageName \n - Timestamp: $timeStamp \n - Package Message: $packageMessage";
   }
 }
 
-NotificationEvent _notificationEvent(String event) {
-  return new NotificationEvent(event);
+NotificationEvent _notificationEvent(dynamic data) {
+  return new NotificationEvent.fromMap(data);
 }
 
 class Notifications {

--- a/packages/notifications/pubspec.yaml
+++ b/packages/notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: notifications
 description: A plugin for tracking notifications on the device. Works exclusively for Android.
-version: 0.1.0
+version: 0.4.0
 author: CACHET Team <cph.cachet@gmail.com>
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/notifications
 


### PR DESCRIPTION
The **notifications** package does provide `packageName` from the *StatusBarNotification* object but also wanted to provide the notification message (body) on the payload.

This PR address that need by providing it as `HashMap` with the keys `packageName` and `packageMessage` just in case someone wants to use such data on another app.

Also I updated the `.gitignore` file to handle extra files generated while using [vs-code java](https://github.com/redhat-developer/vscode-java/issues/618) extension (it is a bug).

Cheers! 🍰 