### PR TITLE
Change http to https in call to OpenWeatherMap API

### DIFF
--- a/packages/weather/lib/src/weather_factory.dart
+++ b/packages/weather/lib/src/weather_factory.dart
@@ -95,7 +95,7 @@ class WeatherFactory {
   }
 
   String _buildUrl(String tag, String cityName, double lat, double lon) {
-    String url = 'http://api.openweathermap.org/data/2.5/' + '$tag?';
+    String url = 'https://api.openweathermap.org/data/2.5/' + '$tag?';
 
     if (cityName != null) {
       url += 'q=$cityName&';


### PR DESCRIPTION
HTTP call fails in apps where only HTTPS is allowed.
API is accessible just as well using http and https.