### PR TITLE
[health]Fix/call to health types

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -203,9 +203,13 @@ class HealthPlugin(val activity: Activity, val channel: MethodChannel) : MethodC
 
     fun callToHealthTypes(call: MethodCall): FitnessOptions {
         val typesBuilder = FitnessOptions.builder()
-        val args = call.arguments as HashMap<*, *>
-        for (key in args) {
-            val dataType = keyToHealthDataType(key.toString())
+        val args = (call.arguments as HashMap<*, *>)
+        val types = args["types"] as ArrayList<*>
+        for (typeKey in types){
+            if(typeKey !is String){
+                continue
+            }
+            val dataType = keyToHealthDataType(typeKey)
             typesBuilder.addDataType(dataType)
         }
         return typesBuilder.build()

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -203,14 +203,11 @@ class HealthPlugin(val activity: Activity, val channel: MethodChannel) : MethodC
 
     fun callToHealthTypes(call: MethodCall): FitnessOptions {
         val typesBuilder = FitnessOptions.builder()
-        val args = (call.arguments as HashMap<*, *>)
+        val args = call.arguments as HashMap<*, *>
         val types = args["types"] as ArrayList<*>
-        for (typeKey in types){
-            if(typeKey !is String){
-                continue
-            }
-            val dataType = keyToHealthDataType(typeKey)
-            typesBuilder.addDataType(dataType)
+        for (typeKey in types) {
+            if (typeKey !is String) continue
+            typesBuilder.addDataType(keyToHealthDataType(typeKey), FitnessOptions.ACCESS_READ)
         }
         return typesBuilder.build()
     }

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -201,7 +201,7 @@ class HealthPlugin(val activity: Activity, val channel: MethodChannel) : MethodC
         }
     }
 
-    fun callToHealthTypes(call: MethodCall): FitnessOptions {
+    private fun callToHealthTypes(call: MethodCall): FitnessOptions {
         val typesBuilder = FitnessOptions.builder()
         val args = call.arguments as HashMap<*, *>
         val types = args["types"] as ArrayList<*>


### PR DESCRIPTION
### Describe the bug
- `callToHealthTypes` method calls `keyToHealthDataType` with key that is `ArrayList.toString()`.
- That key is wrong format. Example: `[WEIGHT]`

### Fixes
- Fix to `callToHealthTypes` use correct key.