### PR TITLE
[health]Fix fitnessOptions of getData

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -172,7 +172,7 @@ class HealthPlugin(val activity: Activity, val channel: MethodChannel) : MethodC
         /// Start a new thread for doing a GoogleFit data lookup
         thread {
             try {
-
+                val fitnessOptions = FitnessOptions.builder().addDataType(dataType).build()
                 val googleSignInAccount = GoogleSignIn.getAccountForExtension(activity.applicationContext, fitnessOptions)
 
                 val response = Fitness.getHistoryClient(activity.applicationContext, googleSignInAccount)


### PR DESCRIPTION
### Describe the bug
`GoogleSignIn.getAccountForExtension` in `HelathPlugin.kt#getData` uses permissions that is not requested. Then, `GoogleSignIn.getAccountForExtension`  returns no account. So `Fitness.getHistoryClient` returns always empty data points.

### Fixes
- Fix to `getHistoryClient` use optimal permissions.