### PR TITLE
Fix Hot Restart crash & infinity dB with dispose

### DIFF
--- a/packages/noise_meter/example/lib/main.dart
+++ b/packages/noise_meter/example/lib/main.dart
@@ -23,9 +23,10 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     _noiseMeter = new NoiseMeter(onError);
   }
- @override
+
+  @override
   void dispose() {
-    _noiseSubscription.cancel();
+    _noiseSubscription?.cancel();
     super.dispose();
   }
 

--- a/packages/noise_meter/example/lib/main.dart
+++ b/packages/noise_meter/example/lib/main.dart
@@ -23,6 +23,11 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     _noiseMeter = new NoiseMeter(onError);
   }
+ @override
+  void dispose() {
+    _noiseSubscription.cancel();
+    super.dispose();
+  }
 
   void onData(NoiseReading noiseReading) {
     this.setState(() {


### PR DESCRIPTION
Flutter: 1.22.4
compileSdkVersion: 24 
Physical Device: Z999 
Description: App crashes upon hot restart, and prints out infinity (maxDB & minDB)
Fix: Dispose stream