### PR TITLE
health: bug in requestAuthorization

### DIFF
--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -23,7 +23,6 @@ class HealthFactory {
         types.add(HealthDataType.WEIGHT);
       if(!types.contains(HealthDataType.HEIGHT))
         types.add(HealthDataType.HEIGHT);
-      types = types.toSet().toList();
     }
 
     List<String> keys = types.map((e) => _enumToString(e)).toList();

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -19,8 +19,10 @@ class HealthFactory {
   Future<bool> requestAuthorization(List<HealthDataType> types) async {
     /// If BMI is requested, then also ask for weight and height
     if (types.contains(HealthDataType.BODY_MASS_INDEX)) {
-      types.add(HealthDataType.WEIGHT);
-      types.add(HealthDataType.HEIGHT);
+      if(!types.contains(HealthDataType.WEIGHT))
+        types.add(HealthDataType.WEIGHT);
+      if(!types.contains(HealthDataType.HEIGHT))
+        types.add(HealthDataType.HEIGHT);
       types = types.toSet().toList();
     }
 


### PR DESCRIPTION
### The Problem
When the function `requestAuthorization` is invoked multiple times with a list of types containing the type `BODY_MASS_INDEX`, the function tends to incrementally add `HEIGHT` and `WEIGHT` on every invocation. The `.toSet().toList()` does not seem to remove the duplicates. 

### Proposed solution
Suggested changes will only add the data types if they are not already present in the input list. This avoids the call to `.toSet.toList()`.