### PR TITLE
Remove handleError on stepCountStream

### DIFF
--- a/packages/pedometer/lib/pedometer.dart
+++ b/packages/pedometer/lib/pedometer.dart
@@ -62,16 +62,9 @@ class Pedometer {
 
   /// Returns the steps taken since last system boot.
   /// Events may come with a delay.
-  static Stream<StepCount> get stepCountStream =>
-      _stepCountChannel
-          .receiveBroadcastStream()
-          .map((event) => StepCount._(event))
-          .handleError(_onError);
-
-  static void _onError(dynamic e) {
-    PlatformException exception = e as PlatformException;
-    print('ERROR: ${exception.message}');
-  }
+  static Stream<StepCount> get stepCountStream => _stepCountChannel
+      .receiveBroadcastStream()
+      .map((event) => StepCount._(event));
 }
 
 /// A DTO for steps taken containing the number of steps taken.


### PR DESCRIPTION
This fixes a bug where listeners cannot actually detect if there is an error with `stepCountStream` since it is 'handled' here. I noticed this when the example didn't display that step count was unavailable when it should, but with this change it does.

I also ran `flutter format .`.

This should close #286.