### PR TITLE
SwiftActivityRecognitionFlutterPlugin class fix

### DIFF
--- a/packages/activity_recognition_flutter/ios/Classes/SwiftActivityRecognitionFlutterPlugin.swift
+++ b/packages/activity_recognition_flutter/ios/Classes/SwiftActivityRecognitionFlutterPlugin.swift
@@ -6,9 +6,9 @@ import CoreMotion
 public class SwiftActivityRecognitionFlutterPlugin: NSObject, FlutterPlugin {
 
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let handler = ActivityStreamHandler()
-    let channel = FlutterMethodChannel(name: "activity_recognition_flutter", binaryMessenger: registrar.messenger())
-    handler.setStreamHandler(handler)
+    let handler = ActivityStreamHandler() 
+    let channel = FlutterEventChannel(name: "activity_recognition_flutter", binaryMessenger: registrar.messenger())
+    channel.setStreamHandler(handler)
   }
 }
 public class ActivityStreamHandler: NSObject, FlutterStreamHandler {


### PR DESCRIPTION
The "SwiftActivityRecognitionFlutterPlugin" Class was unable to compile on iOS because of the following error:

_Value of type 'ActivityStreamHandler' has no member 'setStreamHandler'_

Tested on iPhone XS with iOS 14.4.