### PR TITLE
Update ActivityRecognitionFlutterPlugin.java

### DIFF
--- a/packages/activity_recognition_flutter/android/src/main/java/dk/cachet/activity_recognition_flutter/ActivityRecognitionFlutterPlugin.java
+++ b/packages/activity_recognition_flutter/android/src/main/java/dk/cachet/activity_recognition_flutter/ActivityRecognitionFlutterPlugin.java
@@ -166,4 +166,3 @@ public class ActivityRecognitionFlutterPlugin implements FlutterPlugin, EventCha
         }
     }
   }
-}


### PR DESCRIPTION
Removed extra "}" in the ActivityRecognitionFlutterPlugin class that caused the ^4.0.1 version not to run on Android.