### PR TITLE
Update the documentation for the activity recognition plugin's service.

### DIFF
--- a/packages/activity_recognition_flutter/README.md
+++ b/packages/activity_recognition_flutter/README.md
@@ -23,7 +23,11 @@ Add the following entries inside the `<manifest>` tag:
 Next, add the plugin's service inside the `<application>` tag:
 
 ```xml
-<service android:name="dk.cachet.activity_recognition_flutter.ActivityRecognizedService" />
+<receiver android:name="dk.cachet.activity_recognition_flutter.ActivityRecognizedBroadcastReceiver"/>
+<service
+   android:name="dk.cachet.activity_recognition_flutter.ActivityRecognizedService"
+   android:permission="android.permission.BIND_JOB_SERVICE"
+   android:exported="true"/>
 <service android:name="dk.cachet.activity_recognition_flutter.ForegroundService" />
 ```
 


### PR DESCRIPTION
This was outdated since the null safety migration. Without this change the plugin does not receive any information.