### PR TITLE
fix: check if eventSink is nil before accessing it

### DIFF
--- a/packages/audio_streamer/ios/Classes/SwiftAudioStreamerPlugin.swift
+++ b/packages/audio_streamer/ios/Classes/SwiftAudioStreamerPlugin.swift
@@ -29,6 +29,10 @@ public class SwiftAudioStreamerPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   }
 
   @objc func handleInterruption(notification: Notification) {
+    // If no eventSink to emit events to, do nothing (wait)
+    if (eventSink == nil) {
+        return
+    }
       // To be implemented.
     eventSink!(FlutterError(code: "100", message: "Recording was interrupted", details: "Another process interrupted recording."))
   }


### PR DESCRIPTION
This pull request refers to this issue: https://github.com/cph-cachet/flutter-plugins/issues/266. On closing and reopening the app on iOS the communication channel is nil. To avoid a crash, a nil check is performed. 