### PR TITLE
Enable testability for HealthDataPoint

### DIFF
--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -12,7 +12,8 @@ class HealthDataPoint {
   String _sourceId;
   String _sourceName;
 
-  HealthDataPoint._(
+  @visibleForTesting
+  HealthDataPoint(
       this._value,
       this._type,
       this._unit,

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -55,7 +55,7 @@ class HealthFactory {
     final bmiHealthPoints = <HealthDataPoint>[];
     for (var i = 0; i < weights.length; i++) {
       final bmiValue = weights[i].value.toDouble() / (h * h);
-      final x = HealthDataPoint._(bmiValue, dataType, unit, weights[i].dateFrom,
+      final x = HealthDataPoint(bmiValue, dataType, unit, weights[i].dateFrom,
           weights[i].dateTo, _platformType, _deviceId!, '', '');
 
       bmiHealthPoints.add(x);


### PR DESCRIPTION
The `health` package lacked testability for the `HealthDataPoint` type which is a must when the one wants to mock the response of `getHealthDataFromTypes()` function invocation.

The reason is that the `HealthDataPoint` didn't have a public constructor which efficiently made the mock return result of `getHealthDataFromTypes()` unachievable. 

This PR fixes this by making the `HealthDataPoint` constructor public along with providing `@visibleForTesting` annotation for it which generates a compiler warning if the constructor is attempted to be used outside of `test` folder.