### PR TITLE
Add if statement for starting foreground service

### DIFF
--- a/packages/activity_recognition_flutter/android/src/main/java/dk/cachet/activity_recognition_flutter/ActivityRecognitionFlutterPlugin.java
+++ b/packages/activity_recognition_flutter/android/src/main/java/dk/cachet/activity_recognition_flutter/ActivityRecognitionFlutterPlugin.java
@@ -84,7 +84,9 @@ public class ActivityRecognitionFlutterPlugin implements FlutterPlugin, EventCha
         HashMap<String, Object> args = (HashMap<String, Object>) arguments;
         Log.d(TAG, "args: " + args);
         boolean fg = (boolean) args.get("foreground");
-        startForegroundService();
+        if(fg) {
+            startForegroundService();
+        }
         Log.d(TAG, "foreground: " + fg);
 
 


### PR DESCRIPTION
In its current implementation, starting the activity recognition services always implies starting its foreground service since the argument `foreground` is unhandled. For example: `activityRecognition.startStream(runForegroundService: false)` still starts a foreground service. 

I've added a simple if-statement to correct this issue.