### PR TITLE
[carp_background_location 2.0.0] Added field and setter for notificationBigMsg

### DIFF
--- a/packages/carp_background_location/lib/src/location_manager.dart
+++ b/packages/carp_background_location/lib/src/location_manager.dart
@@ -150,7 +150,7 @@ class LocationManager {
   /// Android only.
   set notificationMsg(value) => _notificationMsg = value;
 
-  /// Set the expaneded message of the notification for the background service.
+  /// Set the expanded message of the notification for the background service.
   /// Android only.
   set notificationBigMsg(value) => _notificationBigMsg = value;
 

--- a/packages/carp_background_location/lib/src/location_manager.dart
+++ b/packages/carp_background_location/lib/src/location_manager.dart
@@ -11,7 +11,10 @@ class LocationManager {
   Stream<LocationDto>? _locationStream;
   String _channelName = "BackgroundLocationChannel",
       _notificationTitle = "Background Location",
-      _notificationMsg = "Your location is being tracked";
+      _notificationMsg = "Your location is being tracked",
+      _notificationBigMsg = "Background location is on to keep the app "
+          "up-to-date with your location. This is required for the main "
+          "features to work properly when the app is not running.";
 
   int _interval = 1;
   double _distanceFilter = 0;
@@ -130,6 +133,7 @@ class LocationManager {
             notificationChannelName: _channelName,
             notificationTitle: _notificationTitle,
             notificationMsg: _notificationMsg,
+            notificationBigMsg: _notificationBigMsg,
           )),
       iosSettings: IOSSettings(
         accuracy: _accuracy,
@@ -145,6 +149,10 @@ class LocationManager {
   /// Set the message of the notification for the background service.
   /// Android only.
   set notificationMsg(value) => _notificationMsg = value;
+
+  /// Set the expaneded message of the notification for the background service.
+  /// Android only.
+  set notificationBigMsg(value) => _notificationBigMsg = value;
 
   /// Set the update interval in seconds.
   /// Android only.


### PR DESCRIPTION
Per [this SO question](https://stackoverflow.com/questions/68069748/change-the-text-background-location-is-on-on-the-keep-app-up-tp-date-in-carp), one can change the notification title and message of `carp_background_location` like this:

```java
LocationManager().notificationTitle = 'CARP Location Example';
LocationManager().notificationMsg = 'CARP is tracking your location';
```

However, as the SO question shows, this message is only change when the notification is folder, not when expanded. I have thus added a `notificationBigMsg` field and setter where the expanded message can be set like so:

```java
LocationManager().notificationTitle = 'CARP Location Example';
LocationManager().notificationMsg = 'CARP is tracking your location';
LocationManager().notificationBigMsg = "Background location is on to keep the app "
          "up-to-date with your location. This is required for the main "
          "features to work properly when the app is not running.";
```