### PR TITLE
Add sleep in bed to android

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -343,18 +343,28 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
                                                 )
                                         )
                                     }
-
+                                    // Returns time spent in bed in Minutes
                                     if (type == SLEEP_IN_BED) {
-                                        healthData.add(
-                                                hashMapOf(
-                                                        "value" to session.getEndTime(TimeUnit.MINUTES) - session.getStartTime(TimeUnit.MINUTES),
-                                                        "date_from" to session.getStartTime(TimeUnit.MILLISECONDS),
-                                                        "date_to" to session.getEndTime(TimeUnit.MILLISECONDS),
-                                                        "unit" to "MINUTES",
-                                                        "source_name" to session.appPackageName,
-                                                        "source_id" to session.identifier
-                                                )
-                                        )
+                                        val dataSets = response.getDataSet(session)
+                                        for (dataSet in dataSets) {
+                                            for (dataPoint in dataSet.dataPoints) {
+                                                // searching OUT OF BED data
+                                                if (dataPoint.getValue(Field.FIELD_SLEEP_SEGMENT_TYPE).asInt() != 3) {
+                                                    healthData.add(
+                                                            hashMapOf(
+                                                                    "value" to dataPoint.getEndTime(TimeUnit.MINUTES) - dataPoint.getStartTime(TimeUnit.MINUTES),
+                                                                    "date_from" to dataPoint.getStartTime(TimeUnit.MILLISECONDS),
+                                                                    "date_to" to dataPoint.getEndTime(TimeUnit.MILLISECONDS),
+                                                                    "unit" to "MINUTES",
+                                                                    "source_name" to (dataPoint.originalDataSource.appPackageName
+                                                                            ?: (dataPoint.originalDataSource.device?.model
+                                                                                    ?: "unknown")),
+                                                                    "source_id" to dataPoint.originalDataSource.streamIdentifier
+                                                            )
+                                                    )
+                                                }
+                                            }
+                                        }
                                     }
 
                                     // If the sleep session has finer granularity sub-components, extract them:

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -51,6 +51,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
     private var WATER = "WATER"
     private var SLEEP_ASLEEP = "SLEEP_ASLEEP"
     private var SLEEP_AWAKE = "SLEEP_AWAKE"
+    private var SLEEP_IN_BED = "SLEEP_IN_BED"
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL_NAME)
@@ -153,6 +154,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
             WATER -> DataType.TYPE_HYDRATION
             SLEEP_ASLEEP -> DataType.TYPE_SLEEP_SEGMENT
             SLEEP_AWAKE -> DataType.TYPE_SLEEP_SEGMENT
+            SLEEP_IN_BED -> DataType.TYPE_SLEEP_SEGMENT
             else -> DataType.TYPE_STEP_COUNT_DELTA
         }
     }
@@ -175,6 +177,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
             WATER -> Field.FIELD_VOLUME
             SLEEP_ASLEEP -> Field.FIELD_SLEEP_SEGMENT_TYPE
             SLEEP_AWAKE -> Field.FIELD_SLEEP_SEGMENT_TYPE
+            SLEEP_IN_BED -> Field.FIELD_SLEEP_SEGMENT_TYPE
             else -> Field.FIELD_PERCENTAGE
         }
     }
@@ -341,6 +344,19 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
                                         )
                                     }
 
+                                    if (type == SLEEP_IN_BED) {
+                                        healthData.add(
+                                                hashMapOf(
+                                                        "value" to session.getEndTime(TimeUnit.MINUTES) - session.getStartTime(TimeUnit.MINUTES),
+                                                        "date_from" to session.getStartTime(TimeUnit.MILLISECONDS),
+                                                        "date_to" to session.getEndTime(TimeUnit.MILLISECONDS),
+                                                        "unit" to "MINUTES",
+                                                        "source_name" to session.appPackageName,
+                                                        "source_id" to session.identifier
+                                                )
+                                        )
+                                    }
+
                                     // If the sleep session has finer granularity sub-components, extract them:
                                     if (type == SLEEP_AWAKE) {
                                         val dataSets = response.getDataSet(session)
@@ -387,7 +403,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
             if (typeKey !is String) continue
             typesBuilder.addDataType(keyToHealthDataType(typeKey), FitnessOptions.ACCESS_READ)
             typesBuilder.addDataType(keyToHealthDataType(typeKey), FitnessOptions.ACCESS_WRITE)
-            if (typeKey == SLEEP_ASLEEP || typeKey == SLEEP_AWAKE) {
+            if (typeKey == SLEEP_ASLEEP || typeKey == SLEEP_AWAKE || typeKey == SLEEP_IN_BED) {
                 typesBuilder.accessSleepSessions(FitnessOptions.ACCESS_READ)
             }
         }

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -346,24 +346,39 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
                                     // Returns time spent in bed in Minutes
                                     if (type == SLEEP_IN_BED) {
                                         val dataSets = response.getDataSet(session)
-                                        for (dataSet in dataSets) {
-                                            for (dataPoint in dataSet.dataPoints) {
-                                                // searching OUT OF BED data
-                                                if (dataPoint.getValue(Field.FIELD_SLEEP_SEGMENT_TYPE).asInt() != 3) {
-                                                    healthData.add(
-                                                            hashMapOf(
-                                                                    "value" to dataPoint.getEndTime(TimeUnit.MINUTES) - dataPoint.getStartTime(TimeUnit.MINUTES),
-                                                                    "date_from" to dataPoint.getStartTime(TimeUnit.MILLISECONDS),
-                                                                    "date_to" to dataPoint.getEndTime(TimeUnit.MILLISECONDS),
-                                                                    "unit" to "MINUTES",
-                                                                    "source_name" to (dataPoint.originalDataSource.appPackageName
-                                                                            ?: (dataPoint.originalDataSource.device?.model
-                                                                                    ?: "unknown")),
-                                                                    "source_id" to dataPoint.originalDataSource.streamIdentifier
-                                                            )
-                                                    )
+
+                                        // If the sleep session has finer granularity sub-components, extract them:
+                                        if( dataSets.isNotEmpty()){
+                                            for (dataSet in dataSets) {
+                                                for (dataPoint in dataSet.dataPoints) {
+                                                    // searching OUT OF BED data
+                                                    if (dataPoint.getValue(Field.FIELD_SLEEP_SEGMENT_TYPE).asInt() != 3) {
+                                                        healthData.add(
+                                                                hashMapOf(
+                                                                        "value" to dataPoint.getEndTime(TimeUnit.MINUTES) - dataPoint.getStartTime(TimeUnit.MINUTES),
+                                                                        "date_from" to dataPoint.getStartTime(TimeUnit.MILLISECONDS),
+                                                                        "date_to" to dataPoint.getEndTime(TimeUnit.MILLISECONDS),
+                                                                        "unit" to "MINUTES",
+                                                                        "source_name" to (dataPoint.originalDataSource.appPackageName
+                                                                                ?: (dataPoint.originalDataSource.device?.model
+                                                                                        ?: "unknown")),
+                                                                        "source_id" to dataPoint.originalDataSource.streamIdentifier
+                                                                )
+                                                        )
+                                                    }
                                                 }
                                             }
+                                        } else {
+                                            healthData.add(
+                                                    hashMapOf(
+                                                            "value" to session.getEndTime(TimeUnit.MINUTES) - session.getStartTime(TimeUnit.MINUTES),
+                                                            "date_from" to session.getStartTime(TimeUnit.MILLISECONDS),
+                                                            "date_to" to session.getEndTime(TimeUnit.MILLISECONDS),
+                                                            "unit" to "MINUTES",
+                                                            "source_name" to session.appPackageName,
+                                                            "source_id" to session.identifier
+                                                    )
+                                            )
                                         }
                                     }
 

--- a/packages/health/lib/src/data_types.dart
+++ b/packages/health/lib/src/data_types.dart
@@ -100,6 +100,7 @@ const List<HealthDataType> _dataTypeKeysAndroid = [
   HealthDataType.DISTANCE_DELTA,
   HealthDataType.SLEEP_AWAKE,
   HealthDataType.SLEEP_ASLEEP,
+  HealthDataType.SLEEP_IN_BED,
   HealthDataType.WATER,
 ];
 


### PR DESCRIPTION
The README states that SLEEP_IN_BED feature is available when in fact it is not.

Apple Health module of this plugin returns `SLEEP_IN_BED` value as a time that User [has spent in bed](https://developer.apple.com/documentation/healthkit/hkcategoryvaluesleepanalysis#overview). 

Google Fit doesn't provide the same functionality but it can provide us data on when the user [gets out of bed during their sleep session](https://developers.google.com/fit/datatypes/sleep). By filtering it out, we can return data which should give us a similar information to that of an Apple Health Kit.
