### PR TITLE
Health - Different read and write permissions on iOS

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -85,17 +85,31 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
     func requestAuthorization(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? NSDictionary
-        let types = (arguments?["types"] as? Array) ?? []
+        let bothTypes = (arguments?["types"] as? Array) ?? []
+        var readTypes = (arguments?["readTypes"] as? Array) ?? []
+        var writeTypes = (arguments?["writeTypes"] as? Array) ?? []
 
-        var typesToRequest = Set<HKSampleType>()
+        //Handle user just requesting the types for identical read and write permissions.
+        if bothTypes.count > 0 {
+            readTypes = bothTypes
+            writeTypes = bothTypes
+        }
 
-        for key in types {
+        var readTypesToRequest = Set<HKSampleType>()
+        var writeTypesToRequest = Set<HKSampleType>()
+
+        for key in readTypes {
             let keyString = "\(key)"
-            typesToRequest.insert(dataTypeLookUp(key: keyString))
+            readTypesToRequest.insert(dataTypeLookUp(key: keyString))
+        }
+
+        for key in writeTypes {
+            let keyString = "\(key)"
+            writeTypesToRequest.insert(dataTypeLookUp(key: keyString))
         }
 
         if #available(iOS 11.0, *) {
-            healthStore.requestAuthorization(toShare: typesToRequest, read: typesToRequest) { (success, error) in
+            healthStore.requestAuthorization(toShare: writeTypesToRequest, read: readTypesToRequest) { (success, error) in
                 result(success)
             }
         }

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -165,10 +165,8 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
         let query = HKSampleQuery(sampleType: dataType, predicate: predicate, limit: limit, sortDescriptors: [sortDescriptor]) {
             x, samplesOrNil, error in
-
             switch samplesOrNil {
             case let (samples as [HKQuantitySample]) as Any:
-                
                 DispatchQueue.main.async {
                     result(samples.map { sample -> NSDictionary in
                         let unit = self.unitLookUp(key: dataTypeKey)
@@ -217,7 +215,10 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                             "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
                             "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                             "source_id": sample.sourceRevision.source.bundleIdentifier,
-                            "source_name": sample.sourceRevision.source.name
+                            "source_name": sample.sourceRevision.source.name,
+                            "workoutType": sample.workoutActivityType.rawValue,
+                            "totalDistance": sample.totalDistance?.doubleValue(for: HKUnit.meter()) ?? 0,
+                            "totalEnergyBurned": sample.totalEnergyBurned?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
                         ]
                     })
                 }

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -13,6 +13,10 @@ class HealthDataPoint {
   String _sourceId;
   String _sourceName;
 
+  num? _totalEnergyBurned;
+  num? _totalDistance;
+  int? _workoutType;
+
   HealthDataPoint(
       this._value,
       this._type,
@@ -31,6 +35,23 @@ class HealthDataPoint {
         type == HealthDataType.SLEEP_AWAKE) {
       this._value = _convertMinutes();
     }
+  }
+
+  HealthDataPoint.forWorkout(
+      this._value,
+      this._type,
+      this._unit,
+      this._dateFrom,
+      this._dateTo,
+      this._platform,
+      this._deviceId,
+      this._sourceId,
+      this._sourceName,
+      this._workoutType,
+      this._totalDistance,
+      this._totalEnergyBurned,
+      ) {
+    //only used for workouts
   }
 
   double _convertMinutes() {
@@ -114,6 +135,17 @@ class HealthDataPoint {
   /// the data point was extracted
   String get sourceName => _sourceName;
 
+  //For workouts these three fields are populated
+  /// For workout data points what was the total distance travelled
+  num get totalDistance => _totalDistance ?? 0;
+
+  /// For workout data points what was the total energy burned
+  num get totalEnergyBurned => _totalEnergyBurned ?? 0;
+
+  /// For workout data points what was the workout type (iOS HealthKit HKWorkoutActivityType)
+  int get workoutType => _workoutType ?? 0;
+
+
   /// An equals (==) operator for comparing two data points
   /// This makes it possible to remove duplicate data points.
   @override
@@ -127,7 +159,10 @@ class HealthDataPoint {
         this.platform == o.platform &&
         this.deviceId == o.deviceId &&
         this.sourceId == o.sourceId &&
-        this.sourceName == o.sourceName;
+        this.sourceName == o.sourceName &&
+        this.workoutType == o.workoutType &&
+        this.totalEnergyBurned == o.totalEnergyBurned &&
+        this.totalDistance == o.totalDistance;
   }
 
   /// Override required due to overriding the '==' operator

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -68,6 +68,11 @@ class HealthFactory {
 
   /// On iOS you can have different read and write types for Apple HealthKit
   Future<bool> requestIOSAuthorization(List<HealthDataType>? readTypes, List<HealthDataType>? writeTypes ) async {
+
+    if (!Platform.isIOS) {
+      throw _HealthException('requestIOSAuthorization', 'requestIOSAuthorization can only be used on iOS and not $_platformType');
+    }
+
     if (readTypes == null) {
       readTypes = [];
     }

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -208,6 +208,28 @@ class HealthFactory {
         final DateTime to = DateTime.fromMillisecondsSinceEpoch(e['date_to']);
         final String sourceId = e["source_id"];
         final String sourceName = e["source_name"];
+
+        if (dataType == HealthDataType.WORKOUT){
+          final int workoutType = e['workoutType'];
+          final num totalDistance = e['totalDistance'];
+          final num totalEnergyBurned = e['totalEnergyBurned'];
+
+          return HealthDataPoint.forWorkout(
+            value,
+            dataType,
+            unit,
+            from,
+            to,
+            _platformType,
+            _deviceId!,
+            sourceId,
+            sourceName,
+            workoutType,
+            totalDistance,
+            totalEnergyBurned
+          );
+        }
+
         return HealthDataPoint(
           value,
           dataType,


### PR DESCRIPTION
With healthkit you can have different permissions for read and write health types. Created new method specifically for iOS and left the original method call if user wants to request both and for backwards compatibility. 