### PR TITLE
[Health 3.4.0] Resolved concurrent issues with native threads 

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -308,7 +308,11 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
             guard let queryResult = queryResult else {
                 let error = error! as NSError
-                result(FlutterError(code: "\(error.code)", message: error.domain, details: error.localizedDescription))
+                print("Error getting total steps in interval \(error.localizedDescription)")
+                
+                DispatchQueue.main.async {
+                    result(nil)
+                }
                 return
             }
 
@@ -320,7 +324,9 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
             }
 
             let totalSteps = Int(steps)
-            result(totalSteps)
+            DispatchQueue.main.async {
+                result(totalSteps)
+            }
         }
 
         HKHealthStore().execute(query)

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -224,19 +224,19 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
             switch samplesOrNil {
             case let (samples as [HKQuantitySample]) as Any:
                 
+                let dictionaries = samples.map { sample -> NSDictionary in
+                    let unit = self.unitLookUp(key: dataTypeKey)
+                    return [
+                        "uuid": "\(sample.uuid)",
+                        "value": sample.quantity.doubleValue(for: unit),
+                        "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
+                        "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
+                        "source_id": sample.sourceRevision.source.bundleIdentifier,
+                        "source_name": sample.sourceRevision.source.name
+                    ]
+                }
                 DispatchQueue.main.async {
-                    result(samples.map { sample -> NSDictionary in
-                        let unit = self.unitLookUp(key: dataTypeKey)
-
-                        return [
-                            "uuid": "\(sample.uuid)",
-                            "value": sample.quantity.doubleValue(for: unit),
-                            "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
-                            "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
-                            "source_id": sample.sourceRevision.source.bundleIdentifier,
-                            "source_name": sample.sourceRevision.source.name
-                        ]
-                    })
+                    result(dictionaries)
                 }
                 
             case var (samplesCategory as [HKCategorySample]) as Any:
@@ -249,32 +249,35 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                 if (dataTypeKey == self.SLEEP_ASLEEP) {
                     samplesCategory = samplesCategory.filter { $0.value == 1 }
                 }
-                
+                let categories = samplesCategory.map { sample -> NSDictionary in
+                    return [
+                        "uuid": "\(sample.uuid)",
+                        "value": sample.value,
+                        "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
+                        "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
+                        "source_id": sample.sourceRevision.source.bundleIdentifier,
+                        "source_name": sample.sourceRevision.source.name
+                    ]
+                }
                 DispatchQueue.main.async {
-                    result(samplesCategory.map { sample -> NSDictionary in
-                        return [
-                            "uuid": "\(sample.uuid)",
-                            "value": sample.value,
-                            "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
-                            "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
-                            "source_id": sample.sourceRevision.source.bundleIdentifier,
-                            "source_name": sample.sourceRevision.source.name
-                        ]
-                    })
+                    result(categories)
                 }
                 
             case let (samplesWorkout as [HKWorkout]) as Any:
+                
+                let dictionaries = samplesWorkout.map { sample -> NSDictionary in
+                    return [
+                        "uuid": "\(sample.uuid)",
+                        "value": Int(sample.duration),
+                        "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
+                        "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
+                        "source_id": sample.sourceRevision.source.bundleIdentifier,
+                        "source_name": sample.sourceRevision.source.name
+                    ]
+                }
+                
                 DispatchQueue.main.async {
-                    result(samplesWorkout.map { sample -> NSDictionary in
-                        return [
-                            "uuid": "\(sample.uuid)",
-                            "value": Int(sample.duration),
-                            "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
-                            "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
-                            "source_id": sample.sourceRevision.source.bundleIdentifier,
-                            "source_name": sample.sourceRevision.source.name
-                        ]
-                    })
+                    result(dictionaries)
                 }
                 
             default:

--- a/packages/health/lib/health.dart
+++ b/packages/health/lib/health.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -105,9 +105,9 @@ class HealthFactory {
     if (_platformType == PlatformType.ANDROID) _handleBMI(mTypes, mPermissions);
 
     List<String> keys = mTypes.map((e) => _enumToString(e)).toList();
-    final bool isAuthorized = await _channel.invokeMethod(
+    final bool? isAuthorized = await _channel.invokeMethod(
         'requestAuthorization', {'types': keys, "permissions": mPermissions});
-    return isAuthorized;
+    return isAuthorized ?? false;
   }
 
   static void _handleBMI(List<HealthDataType> mTypes, List<int> mPermissions) {
@@ -262,7 +262,7 @@ class HealthFactory {
     final dataType = message["dataType"];
     final dataPoints = message["dataPoints"];
     final device = message["deviceId"];
-    final unit = _dataTypeToUnit[dataType]!;    
+    final unit = _dataTypeToUnit[dataType]!;
     final list = dataPoints.map<HealthDataPoint>((e) {
       final num value = e['value'];
       final DateTime from = DateTime.fromMillisecondsSinceEpoch(e['date_from']);
@@ -317,7 +317,7 @@ class HealthFactory {
       'startDate': startDate.millisecondsSinceEpoch,
       'endDate': endDate.millisecondsSinceEpoch
     };
-    final stepsCount = await _channel.invokeMethod(
+    final stepsCount = await _channel.invokeMethod<int?>(
       'getTotalStepsInInterval',
       args,
     );


### PR DESCRIPTION
The main objective of this PR is to 
-  improve concurrency by using Dart Isolates to offload time consuming tasks from the main thread. (see #313)
- overhaul the way how threads was created and utilized in HealthPlugin.kt on Android

> 1.  The current implementation would create a new thread each time a GoogleFit Task was requested. This is not an ideal situation as creating thread is an expensive operation. This PR fixed this issue by tapping available threads from a thread pool of fixed size (of 4).

> 2. The current implementation was calling GoogleFit API methods directly inside a thread, e.g.

```
thread {
 ..
//Is it really safe to do like this?  Not sure if GoogleFit API is thread-safe.
val response = Fitness.getHistoryClient(activity!!.applicationContext, googleSignInAccount)
                        .readData(request)
val result = Tasks.await(response)

...

}
```

> This may have caused some crashes, (see #151, #415, #470), for applications in release mode, as GoogleFIt API may not be thread safe. Instead, this PR tried to get around these crashes by setting up a method handler to be executed in a non-main thread, e.g.

```
Fitness.getHistoryClient(activity, gsa).readData(request)
            .addOnFailureListener(errHandler(result))
// the handler method will be executed in a non-main thread tapped from the threadPool
            .addOnSuccessListener(threadPool!!, handler)

```

> This PR could therefore resolve the following issues:

- #313
- #151 
- #415
- #470