### PR TITLE
Healthkit CategorySample

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -189,9 +189,15 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
         
         print("Successfully called writeData with value of \(value) and type of \(type)")
         
-        let quantity = HKQuantity(unit: unitLookUp(key: type), doubleValue: value)
-        
-        let sample = HKQuantitySample(type: dataTypeLookUp(key: type) as! HKQuantityType, quantity: quantity, start: dateFrom, end: dateTo)
+        let sample: HKObject
+      
+        if (unitLookUp(key: type) == HKUnit.init(from: "")) {
+          sample = HKCategorySample(type: dataTypeLookUp(key: type) as! HKCategoryType, value: Int(value), start: dateFrom, end: dateTo)
+        } else {
+          let quantity = HKQuantity(unit: unitLookUp(key: type), doubleValue: value)
+          
+          sample = HKQuantitySample(type: dataTypeLookUp(key: type) as! HKQuantityType, quantity: quantity, start: dateFrom, end: dateTo)
+        }
         
         HKHealthStore().save(sample, withCompletion: { (success, error) in
             if let err = error {


### PR DESCRIPTION
When Healthkit needs a CatergorySample the code would crash. Now the code checks if the unit is `HKUnit.init(from: "")` which means that it doesn't need a quantity for the session.