### PR TITLE
permission_handler 8.3.0, typo fixed, read me for permission_handler

### DIFF
--- a/packages/audio_streamer/README.md
+++ b/packages/audio_streamer/README.md
@@ -3,15 +3,17 @@
 Streaming of PCM audio from Android and iOS with a sample rate of 44,100 Hz
 
 ## Permissions
-On *Android* you need to add a permission to `AndroidManifest.xml`:
+
+On _Android_ you need to add a permission to `AndroidManifest.xml`:
 
 ```xml
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
 ```
 
-On *iOS* enable the following:
-* Capabilities > Background Modes > _Audio, AirPlay and Picture in Picture_
-* In the Runner Xcode project edit the _Info.plist_ file. Add an entry for _'Privacy - Microphone Usage Description'_
+On _iOS_ enable the following:
+
+- Capabilities > Background Modes > _Audio, AirPlay and Picture in Picture_
+- In the Runner Xcode project edit the _Info.plist_ file. Add an entry for _'Privacy - Microphone Usage Description'_
 
 When editing the `Info.plist` file manually, the entries needed are:
 
@@ -24,14 +26,34 @@ When editing the `Info.plist` file manually, the entries needed are:
 </array>
 ```
 
-## Example Usage 
+- Add the code inside ##### in the iOS Podfile
+
+```
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    #####
+     target.build_configurations.each do |config|
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        ## dart: PermissionGroup.microphone
+        'PERMISSION_MICROPHONE=1',
+      ]
+    end
+    #####
+  end
+end
+```
+
+## Example Usage
+
 See the file `example/lib/main.dart` for a fully fledged example app using the plugin.
 
 ```dart
   AudioStreamer _streamer = AudioStreamer();
   bool _isRecording = false;
   List<double> _audio = [];
-  
+
   void onAudio(List<double> buffer) {
     _audio.addAll(buffer);
     double secondsRecorded = _audio.length.toDouble() / _streamer.sampleRate.toDouble();

--- a/packages/audio_streamer/lib/audio_streamer.dart
+++ b/packages/audio_streamer/lib/audio_streamer.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 /*
- * A [AudioStreamer] object is reponsible for connecting
+ * A [AudioStreamer] object is responsible for connecting
  * to the native environment and streaming audio from the microphone.*
  */
 const String EVENT_CHANNEL_NAME = 'audio_streamer.eventChannel';
@@ -14,8 +14,7 @@ class AudioStreamer {
 
   static int get sampleRate => 44100;
 
-  static const EventChannel _noiseEventChannel =
-      EventChannel(EVENT_CHANNEL_NAME);
+  static const EventChannel _noiseEventChannel = EventChannel(EVENT_CHANNEL_NAME);
 
   Stream<List<double>>? _stream;
   StreamSubscription<List<dynamic>>? _subscription;
@@ -36,12 +35,10 @@ class AudioStreamer {
   }
 
   /// Verify that it was granted
-  static Future<bool> checkPermission() async =>
-      Permission.microphone.request().isGranted;
+  static Future<bool> checkPermission() async => Permission.microphone.request().isGranted;
 
   /// Request the microphone permission
-  static Future<void> requestPermission() async =>
-      Permission.microphone.request();
+  static Future<void> requestPermission() async => Permission.microphone.request();
 
   Future<bool> start(Function onData, Function handleError) async {
     if (_isRecording) {

--- a/packages/audio_streamer/pubspec.yaml
+++ b/packages/audio_streamer/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_streamer
 description: Streaming of Pulse-code modulation (PCM) audio from Android and iOS
-version: 2.0.3
+version: 2.1.0
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.12.0"
 
 dependencies:
-  permission_handler: ^8.1.0
+  permission_handler: ^8.3.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
iOS is not working because Podfile was not correctly set up. So I added how to set up the Podfile file in the README.md.