### PR TITLE
Don't ignore ios plugin podspec files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ packages/activity_recognition_flutter/example/.flutter-plugins-dependencies
 packages/activity_recognition_flutter/example/.flutter-plugins-dependencies
 packages/activity_recognition_flutter/example/.flutter-plugins-dependencies
 packages/activity_recognition_flutter/example/.flutter-plugins-dependencies
-*.podspec
+**/ios/Flutter/Flutter.podspec
 *.sh
 *.pbxproj
 packages/activity_recognition_flutter/example/.flutter-plugins-dependencies


### PR DESCRIPTION
The latest upload on pub.dev for audio_streamer is missing the podspec because it is ignored in the .gitignore. This fixes that.