### PR TITLE
[health] fixes health value type toJson and fromJson

### DIFF
--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -46,7 +46,7 @@ class HealthDataPoint {
   /// Converts a json object to the [HealthDataPoint]
   factory HealthDataPoint.fromJson(json) {
     HealthValue healthValue;
-    if (json['data_type'] == 'audiogram') {
+    if (json['data_type'] == 'AUDIOGRAM') {
       healthValue = AudiogramHealthValue.fromJson(json['value']);
     } else if (json['data_type'] == 'WORKOUT') {
       healthValue = WorkoutHealthValue.fromJson(json['value']);

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -48,6 +48,8 @@ class HealthDataPoint {
     HealthValue healthValue;
     if (json['data_type'] == 'audiogram') {
       healthValue = AudiogramHealthValue.fromJson(json['value']);
+    } else if (json['data_type'] == 'WORKOUT') {
+      healthValue = WorkoutHealthValue.fromJson(json['value']);
     } else {
       healthValue = NumericHealthValue.fromJson(json['value']);
     }

--- a/packages/health/lib/src/health_value_types.dart
+++ b/packages/health/lib/src/health_value_types.dart
@@ -46,8 +46,7 @@ class AudiogramHealthValue extends HealthValue {
   List<num> _leftEarSensitivities;
   List<num> _rightEarSensitivities;
 
-  AudiogramHealthValue(this._frequencies, this._leftEarSensitivities,
-      this._rightEarSensitivities);
+  AudiogramHealthValue(this._frequencies, this._leftEarSensitivities, this._rightEarSensitivities);
 
   List<num> get frequencies => _frequencies;
   List<num> get leftEarSensitivities => _leftEarSensitivities;
@@ -61,9 +60,7 @@ class AudiogramHealthValue extends HealthValue {
   }
 
   factory AudiogramHealthValue.fromJson(json) {
-    return AudiogramHealthValue(
-        List<num>.from(json['frequencies']),
-        List<num>.from(json['leftEarSensitivities']),
+    return AudiogramHealthValue(List<num>.from(json['frequencies']), List<num>.from(json['leftEarSensitivities']),
         List<num>.from(json['rightEarSensitivities']));
   }
 
@@ -82,8 +79,7 @@ class AudiogramHealthValue extends HealthValue {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(frequencies, leftEarSensitivities, rightEarSensitivities);
+  int get hashCode => Object.hash(frequencies, leftEarSensitivities, rightEarSensitivities);
 }
 
 /// A [HealthValue] object for workouts
@@ -101,12 +97,8 @@ class WorkoutHealthValue extends HealthValue {
   int? _totalDistance;
   HealthDataUnit? _totalDistanceUnit;
 
-  WorkoutHealthValue(
-      this._workoutActivityType,
-      this._totalEnergyBurned,
-      this._totalEnergyBurnedUnit,
-      this._totalDistance,
-      this._totalDistanceUnit);
+  WorkoutHealthValue(this._workoutActivityType, this._totalEnergyBurned, this._totalEnergyBurnedUnit,
+      this._totalDistance, this._totalDistanceUnit);
 
   /// The type of the workout.
   HealthWorkoutActivityType get workoutActivityType => _workoutActivityType;
@@ -129,40 +121,33 @@ class WorkoutHealthValue extends HealthValue {
 
   factory WorkoutHealthValue.fromJson(json) {
     return WorkoutHealthValue(
-        HealthWorkoutActivityType.values.firstWhere(
-            (element) => element.typeToString() == json['workoutActivityType']),
-        json['totalEnergyBurned'] != null
-            ? (json['totalEnergyBurned'] as double).toInt()
-            : null,
+        HealthWorkoutActivityType.values.firstWhere((element) => element.typeToString() == json['workoutActivityType']),
+        json['totalEnergyBurned'] != null ? (json['totalEnergyBurned'] as num).toInt() : null,
         json['totalEnergyBurnedUnit'] != null
-            ? HealthDataUnit.values.firstWhere((element) =>
-                element.typeToString() == json['totalEnergyBurnedUnit'])
+            ? HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['totalEnergyBurnedUnit'])
             : null,
-        json['totalDistance'] != null
-            ? (json['totalDistance'] as double).toInt()
-            : null,
+        json['totalDistance'] != null ? (json['totalDistance'] as num).toInt() : null,
         json['totalDistanceUnit'] != null
-            ? HealthDataUnit.values.firstWhere((element) =>
-                element.typeToString() == json['totalDistanceUnit'])
+            ? HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['totalDistanceUnit'])
             : null);
   }
 
   @override
   Map<String, dynamic> toJson() => {
-        'workoutActivityType': _workoutActivityType.toString(),
+        'workoutActivityType': _workoutActivityType.typeToString(),
         'totalEnergyBurned': _totalEnergyBurned,
-        'totalEnergyBurnedUnit': _totalEnergyBurnedUnit?.toString(),
+        'totalEnergyBurnedUnit': _totalEnergyBurnedUnit?.typeToString(),
         'totalDistance': _totalDistance,
-        'totalDistanceUnit': _totalDistanceUnit?.toString(),
+        'totalDistanceUnit': _totalDistanceUnit?.typeToString(),
       };
 
   @override
   String toString() {
-    return """workoutActivityType: ${workoutActivityType.toString()},
+    return """workoutActivityType: ${workoutActivityType.typeToString()},
     totalEnergyBurned: $totalEnergyBurned,
-    totalEnergyBurnedUnit: ${totalEnergyBurnedUnit?.toString()},
+    totalEnergyBurnedUnit: ${totalEnergyBurnedUnit?.typeToString()},
     totalDistance: $totalDistance,
-    totalDistanceUnit: ${totalDistanceUnit?.toString()}""";
+    totalDistanceUnit: ${totalDistanceUnit?.typeToString()}""";
   }
 
   @override
@@ -176,8 +161,8 @@ class WorkoutHealthValue extends HealthValue {
   }
 
   @override
-  int get hashCode => Object.hash(workoutActivityType, totalEnergyBurned,
-      totalEnergyBurnedUnit, totalDistance, totalDistanceUnit);
+  int get hashCode =>
+      Object.hash(workoutActivityType, totalEnergyBurned, totalEnergyBurnedUnit, totalDistance, totalDistanceUnit);
 }
 
 abstract class HealthValue {


### PR DESCRIPTION
close [#598]
factory HealthDataPoint.fromJson(json) does not separate NumericHealthValue and WorkoutHealthValue causing the crash while processing workout data type.
```
{
  "value": {
    "workoutActivityType": "TRADITIONAL_STRENGTH_TRAINING",
    "totalEnergyBurned": 1027,
    "totalEnergyBurnedUnit": "KILOCALORIE",
    "totalDistance": null,
    "totalDistanceUnit": "METER"
  },
  "data_type": "WORKOUT"
  ...
}
```