### PR TITLE
Save the actual measurement range in app_usage

### DIFF
--- a/packages/app_usage/android/src/main/kotlin/dk/cachet/app_usage/Stats.java
+++ b/packages/app_usage/android/src/main/kotlin/dk/cachet/app_usage/Stats.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 /**
  * Created by User on 3/2/15.
@@ -34,17 +35,24 @@ public class Stats {
      * with the corresponding time in foreground in seconds for that application.
      */
     @SuppressWarnings("ResourceType")
-    public static HashMap<String, Double> getUsageMap(Context context, long start, long end) {
+    public static HashMap<String, List<Double>> getUsageMap(Context context, long start, long end) {
         UsageStatsManager manager = (UsageStatsManager) context.getSystemService("usagestats");
         Map<String, UsageStats> usageStatsMap = manager.queryAndAggregateUsageStats(start, end);
-        HashMap<String, Double> usageMap = new HashMap<>();
+        HashMap<String, List<Double>> usageMap = new HashMap<String, List<Double>>();
 
         for (String packageName : usageStatsMap.keySet()) {
             UsageStats us = usageStatsMap.get(packageName);
             try {
                 long timeMs = us.getTotalTimeInForeground();
                 Double timeSeconds = new Double(timeMs / 1000);
-                usageMap.put(packageName, timeSeconds);
+                long timeMsFirst = us.getFirstTimeStamp();
+                Double timeSecondsStart = new Double(timeMsFirst / 1000);
+                long timeMsStop = us.getLastTimeStamp();
+                Double timeSecondsStop = new Double(timeMsStop / 1000);
+                long timeMsLastUse = us.getLastTimeForegroundServiceUsed();
+                Double timeSecondsLastUse = new Double(timeMsLastUse / 1000);
+                List<Double> listT = Arrays.asList(timeSeconds, timeSecondsStart, timeSecondsStop,timeSecondsLastUse);
+                usageMap.put(packageName, listT);
             } catch (Exception e) {
                 Log.d(TAG, "Getting timeInForeground resulted in an exception");
             }

--- a/packages/app_usage/lib/app_usage.dart
+++ b/packages/app_usage/lib/app_usage.dart
@@ -90,14 +90,6 @@ class AppUsage {
       return toReturn;
 
 
-/*
-      Map<String, double> _map = Map<String, double>.from(usage);
-
-      /// Convert each entry in the map to an Application object
-      return _map.keys
-          .map((k) => AppUsageInfo(k, _map[k]!, startDate, endDate))
-          .where((a) => a.usage > Duration(seconds: 0))
-          .toList();*/
 
 
 


### PR DESCRIPTION
The big problem with the previous version is that the range in which the app usage was measured was not saved. This range cannot be set and therefore is not the same as the input time range (see https://github.com/cph-cachet/flutter-plugins/issues/592). Additionally some extra information on appusage is gathered (last time app was in foreground).


In Java (for Android) the following data is now gathered for each app:
1) packageName
2) total time in foreground
3) The start of the range: Get the beginning of the time range this UsageStats represents, measured in seconds since the epoch. This is not the same as the input start date and cannot exactly be set.
4) The end of the range: Get the end of the time range this UsageStats represents, measured in seconds since the epoch. This is not exactly the same as the input end date and cannot exactly be set.
5) The last time the app was in foreground, measured in seconds since epoch.

It is returned to Dart as a Map<String,List<double>>. All lists include four numbers numbers: total time in foreground, start of range, end of range and last time the app was in foreground.

In AppUsageInfo, startDate is now set to the start of the range
endDate is set to the end of the range. lasteForeground is also added.
