### PR TITLE
Add delete() and writeBloodPressure() functions

### DIFF
--- a/packages/health/README.md
+++ b/packages/health/README.md
@@ -11,7 +11,7 @@ The plugin supports:
 - writing audiograms on iOS using the `writeAudiogram` method.
 - accessing total step counts using the `getTotalStepsInInterval` method.
 - cleaning up dublicate data points via the `removeDuplicates` method.
-- removing data of a given type in a selected period of time using the `delete` method (Android only).
+- removing data of a given type in a selected period of time using the `delete` method.
 - writing blood pressure data in a single call using the `saveBloodPressure` method (Android only).
 
 Note that for Android, the target phone **needs** to have [Google Fit](https://www.google.com/fit/) installed and have access to the internet, otherwise this plugin will not work.

--- a/packages/health/README.md
+++ b/packages/health/README.md
@@ -11,6 +11,8 @@ The plugin supports:
 - writing audiograms on iOS using the `writeAudiogram` method.
 - accessing total step counts using the `getTotalStepsInInterval` method.
 - cleaning up dublicate data points via the `removeDuplicates` method.
+- removing data of a given type in a selected period of time using the `delete` method (Android only).
+- writing blood pressure data in a single call using the `saveBloodPressure` method (Android only).
 
 Note that for Android, the target phone **needs** to have [Google Fit](https://www.google.com/fit/) installed and have access to the internet, otherwise this plugin will not work.
 

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -12,8 +12,6 @@ import com.google.android.gms.fitness.Fitness
 import com.google.android.gms.fitness.FitnessActivities
 import com.google.android.gms.fitness.FitnessOptions
 import com.google.android.gms.fitness.data.*
-import com.google.android.gms.fitness.request.DataDeleteRequest
-import java.util.concurrent.TimeUnit
 import com.google.android.gms.fitness.request.DataReadRequest
 import com.google.android.gms.fitness.request.SessionInsertRequest
 import com.google.android.gms.fitness.request.SessionReadRequest
@@ -323,7 +321,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) : MethodCallHandl
     }
   }
 
-  // delete records of the diven type in the time range
+// delete records of the diven type in the time range
   private fun delete(call: MethodCall, result: Result) {
 
     if (activity == null) {
@@ -420,8 +418,6 @@ private fun writeBloodPressure(call: MethodCall, result: Result) {
       result.success(false)
     }
   }
-
-
 
   private fun writeData(call: MethodCall, result: Result) {
 
@@ -907,7 +903,6 @@ private fun writeBloodPressure(call: MethodCall, result: Result) {
     }
     return typesBuilder.build()
   }
-
 
   private fun hasPermissions(call: MethodCall, result: Result) {
 

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -13,6 +13,7 @@ import com.google.android.gms.fitness.FitnessActivities
 import com.google.android.gms.fitness.FitnessOptions
 import com.google.android.gms.fitness.data.*
 import com.google.android.gms.fitness.request.DataReadRequest
+import com.google.android.gms.fitness.request.DataDeleteRequest
 import com.google.android.gms.fitness.request.SessionInsertRequest
 import com.google.android.gms.fitness.request.SessionReadRequest
 import com.google.android.gms.fitness.result.DataReadResponse
@@ -31,6 +32,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.security.Permission
 import java.util.*
 import java.util.concurrent.*
+import java.util.concurrent.TimeUnit
 
 
 const val GOOGLE_FIT_PERMISSIONS_REQUEST_CODE = 1111
@@ -933,7 +935,7 @@ private fun writeBloodPressure(call: MethodCall, result: Result) {
     mResult = result
 
     val isGranted = false
-    
+
     /// Not granted? Ask for permission
     if (!isGranted && activity != null) {
       GoogleSignIn.requestPermissions(

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -937,10 +937,8 @@ private fun writeBloodPressure(call: MethodCall, result: Result) {
     val optionsToRegister = callToHealthTypes(call)
     mResult = result
 
-    val isGranted = GoogleSignIn.hasPermissions(
-      GoogleSignIn.getLastSignedInAccount(activity!!),
-      optionsToRegister
-    )
+    val isGranted = false
+    
     /// Not granted? Ask for permission
     if (!isGranted && activity != null) {
       GoogleSignIn.requestPermissions(

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -390,7 +390,7 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
             guard let samplesOrNil = samplesOrNil, error == nil else {
                 // Handle the error if necessary
-                print("Error deleting \(dataType) Sample: \(err.localizedDescription)")
+                print("Error deleting \(dataType)")
                 return
             }
 

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -15,14 +15,10 @@ class HealthFactory {
   String? _deviceId;
   final _deviceInfo = DeviceInfoPlugin();
 
-  static PlatformType _platformType =
-      Platform.isAndroid ? PlatformType.ANDROID : PlatformType.IOS;
+  static PlatformType _platformType = Platform.isAndroid ? PlatformType.ANDROID : PlatformType.IOS;
 
   /// Check if a given data type is available on the platform
-  bool isDataTypeAvailable(HealthDataType dataType) =>
-      _platformType == PlatformType.ANDROID
-          ? _dataTypeKeysAndroid.contains(dataType)
-          : _dataTypeKeysIOS.contains(dataType);
+  bool isDataTypeAvailable(HealthDataType dataType) => _platformType == PlatformType.ANDROID ? _dataTypeKeysAndroid.contains(dataType) : _dataTypeKeysIOS.contains(dataType);
 
   /// Determines if the data types have been granted with the specified access rights.
   ///
@@ -47,17 +43,11 @@ class HealthFactory {
   ///   with a READ or READ_WRITE access.
   ///
   ///   On Android, this function returns true or false, depending on whether the specified access right has been granted.
-  static Future<bool?> hasPermissions(List<HealthDataType> types,
-      {List<HealthDataAccess>? permissions}) async {
-    if (permissions != null && permissions.length != types.length)
-      throw ArgumentError(
-          "The lists of types and permissions must be of same length.");
+  static Future<bool?> hasPermissions(List<HealthDataType> types, {List<HealthDataAccess>? permissions}) async {
+    if (permissions != null && permissions.length != types.length) throw ArgumentError("The lists of types and permissions must be of same length.");
 
     final mTypes = List<HealthDataType>.from(types, growable: true);
-    final mPermissions = permissions == null
-        ? List<int>.filled(types.length, HealthDataAccess.READ.index,
-            growable: true)
-        : permissions.map((permission) => permission.index).toList();
+    final mPermissions = permissions == null ? List<int>.filled(types.length, HealthDataAccess.READ.index, growable: true) : permissions.map((permission) => permission.index).toList();
 
     /// On Android, if BMI is requested, then also ask for weight and height
     if (_platformType == PlatformType.ANDROID) _handleBMI(mTypes, mPermissions);
@@ -97,34 +87,27 @@ class HealthFactory {
     List<HealthDataAccess>? permissions,
   }) async {
     if (permissions != null && permissions.length != types.length) {
-      throw ArgumentError(
-          'The length of [types] must be same as that of [permissions].');
+      throw ArgumentError('The length of [types] must be same as that of [permissions].');
     }
 
     if (permissions != null) {
       for (int i = 0; i < types.length; i++) {
         final type = types[i];
         final permission = permissions[i];
-        if (type == HealthDataType.ELECTROCARDIOGRAM &&
-            permission != HealthDataAccess.READ) {
-          throw ArgumentError(
-              'Requesting WRITE permission on ELECTROCARDIOGRAM is not allowed.');
+        if (type == HealthDataType.ELECTROCARDIOGRAM && permission != HealthDataAccess.READ) {
+          throw ArgumentError('Requesting WRITE permission on ELECTROCARDIOGRAM is not allowed.');
         }
       }
     }
 
     final mTypes = List<HealthDataType>.from(types, growable: true);
-    final mPermissions = permissions == null
-        ? List<int>.filled(types.length, HealthDataAccess.READ.index,
-            growable: true)
-        : permissions.map((permission) => permission.index).toList();
+    final mPermissions = permissions == null ? List<int>.filled(types.length, HealthDataAccess.READ.index, growable: true) : permissions.map((permission) => permission.index).toList();
 
     // on Android, if BMI is requested, then also ask for weight and height
     if (_platformType == PlatformType.ANDROID) _handleBMI(mTypes, mPermissions);
 
     List<String> keys = mTypes.map((e) => _enumToString(e)).toList();
-    final bool? isAuthorized = await _channel.invokeMethod(
-        'requestAuthorization', {'types': keys, "permissions": mPermissions});
+    final bool? isAuthorized = await _channel.invokeMethod('requestAuthorization', {'types': keys, "permissions": mPermissions});
     return isAuthorized ?? false;
   }
 
@@ -146,45 +129,31 @@ class HealthFactory {
   }
 
   /// Calculate the BMI using the last observed height and weight values.
-  Future<List<HealthDataPoint>> _computeAndroidBMI(
-      DateTime startTime, DateTime endTime) async {
-    List<HealthDataPoint> heights =
-        await _prepareQuery(startTime, endTime, HealthDataType.HEIGHT);
+  Future<List<HealthDataPoint>> _computeAndroidBMI(DateTime startTime, DateTime endTime) async {
+    List<HealthDataPoint> heights = await _prepareQuery(startTime, endTime, HealthDataType.HEIGHT);
 
     if (heights.isEmpty) {
       return [];
     }
 
-    List<HealthDataPoint> weights =
-        await _prepareQuery(startTime, endTime, HealthDataType.WEIGHT);
+    List<HealthDataPoint> weights = await _prepareQuery(startTime, endTime, HealthDataType.WEIGHT);
 
-    double h =
-        (heights.last.value as NumericHealthValue).numericValue.toDouble();
+    double h = (heights.last.value as NumericHealthValue).numericValue.toDouble();
 
     const dataType = HealthDataType.BODY_MASS_INDEX;
     final unit = _dataTypeToUnit[dataType]!;
 
     final bmiHealthPoints = <HealthDataPoint>[];
     for (var i = 0; i < weights.length; i++) {
-      final bmiValue =
-          (weights[i].value as NumericHealthValue).numericValue.toDouble() /
-              (h * h);
-      final x = HealthDataPoint(
-          NumericHealthValue(bmiValue),
-          dataType,
-          unit,
-          weights[i].dateFrom,
-          weights[i].dateTo,
-          _platformType,
-          _deviceId!,
-          '',
-          '');
+      final bmiValue = (weights[i].value as NumericHealthValue).numericValue.toDouble() / (h * h);
+      final x = HealthDataPoint(NumericHealthValue(bmiValue), dataType, unit, weights[i].dateFrom, weights[i].dateTo, _platformType, _deviceId!, '', '');
 
       bmiHealthPoints.add(x);
     }
     return bmiHealthPoints;
   }
 
+  
   /// Saves health data into Apple Health or Google Fit.
   ///
   /// Returns true if successful, false otherwise.
@@ -206,19 +175,14 @@ class HealthFactory {
     DateTime endTime, {
     HealthDataUnit? unit,
   }) async {
-    if (type == HealthDataType.WORKOUT)
-      throw ArgumentError(
-          "Adding workouts should be done using the writeWorkoutData method.");
-    if (startTime.isAfter(endTime))
-      throw ArgumentError("startTime must be equal or earlier than endTime");
+    if (type == HealthDataType.WORKOUT) throw ArgumentError("Adding workouts should be done using the writeWorkoutData method.");
+    if (startTime.isAfter(endTime)) throw ArgumentError("startTime must be equal or earlier than endTime");
     if ({
       HealthDataType.HIGH_HEART_RATE_EVENT,
       HealthDataType.LOW_HEART_RATE_EVENT,
       HealthDataType.IRREGULAR_HEART_RATE_EVENT,
       HealthDataType.ELECTROCARDIOGRAM,
-    }.contains(type))
-      throw ArgumentError(
-          "$type - iOS doesnt support writing this data type in HealthKit");
+    }.contains(type)) throw ArgumentError("$type - iOS doesnt support writing this data type in HealthKit");
 
     // Assign default unit if not specified
     unit ??= _dataTypeToUnit[type]!;
@@ -236,17 +200,52 @@ class HealthFactory {
       value = _alignValue(type).toDouble();
     }
 
-    Map<String, dynamic> args = {
-      'value': value,
-      'dataTypeKey': type.typeToString(),
-      'dataUnitKey': unit.typeToString(),
-      'startTime': startTime.millisecondsSinceEpoch,
-      'endTime': endTime.millisecondsSinceEpoch
-    };
+    Map<String, dynamic> args = {'value': value, 'dataTypeKey': type.typeToString(), 'dataUnitKey': unit.typeToString(), 'startTime': startTime.millisecondsSinceEpoch, 'endTime': endTime.millisecondsSinceEpoch};
     bool? success = await _channel.invokeMethod('writeData', args);
     return success ?? false;
   }
 
+
+  /// Deletes a record of the given type for a given period of time
+  ///
+  /// Returns true if successful, false otherwise.
+  ///
+  /// Parameters:
+  /// * [type] - the value's HealthDataType
+  /// * [startTime] - the start time when this [value] is measured.
+  ///   + It must be equal to or earlier than [endTime].
+  /// * [endTime] - the end time when this [value] is measured.
+  ///   + It must be equal to or later than [startTime].
+  ///   + Simply set [endTime] equal to [startTime] if the blood pressure is measured only at a specific point in time.  
+  Future<bool> delete(HealthDataType type, DateTime startTime, DateTime endTime) async {
+    if (startTime.isAfter(endTime)) throw ArgumentError("startTime must be equal or earlier than endTime");
+
+    Map<String, dynamic> args = {'dataTypeKey': type.typeToString(), 'startTime': startTime.millisecondsSinceEpoch, 'endTime': endTime.millisecondsSinceEpoch};
+    bool? success = await _channel.invokeMethod('delete', args);
+    return success ?? false;
+  }
+
+  /// Saves blood pressure record into Apple Health or Google Fit.
+  ///
+  /// Returns true if successful, false otherwise.
+  ///
+  /// Parameters:
+  /// * [systolic] - the systolic part of the blood pressure
+  /// * [diastolic] - the diastolic part of the blood pressure  
+  /// * [startTime] - the start time when this [value] is measured.
+  ///   + It must be equal to or earlier than [endTime].
+  /// * [endTime] - the end time when this [value] is measured.
+  ///   + It must be equal to or later than [startTime].
+  ///   + Simply set [endTime] equal to [startTime] if the blood pressure is measured only at a specific point in time.  
+  Future<bool> writeBloodPressure(double systolic, double diastolic, DateTime startTime, DateTime endTime) async {
+    if (startTime.isAfter(endTime)) throw ArgumentError("startTime must be equal or earlier than endTime");
+
+    Map<String, dynamic> args = {'systolic': systolic, 'diastolic': diastolic, 'startTime': startTime.millisecondsSinceEpoch, 'endTime': endTime.millisecondsSinceEpoch};
+    bool? success = await _channel.invokeMethod('writeBloodPressure', args);
+    return success ?? false;
+  }  
+
+  
   /// Saves audiogram into Apple Health.
   ///
   /// Returns true if successful, false otherwise.
@@ -261,26 +260,11 @@ class HealthFactory {
   ///   + It must be equal to or later than [startTime].
   ///   + Simply set [endTime] equal to [startTime] if the audiogram is measured only at a specific point in time.
   /// * [metadata] - optional map of keys, both HKMetadataKeyExternalUUID and HKMetadataKeyDeviceName are required
-  Future<bool> writeAudiogram(
-      List<double> frequencies,
-      List<double> leftEarSensitivities,
-      List<double> rightEarSensitivities,
-      DateTime startTime,
-      DateTime endTime,
-      {Map<String, dynamic>? metadata}) async {
-    if (frequencies.isEmpty ||
-        leftEarSensitivities.isEmpty ||
-        rightEarSensitivities.isEmpty)
-      throw ArgumentError(
-          "frequencies, leftEarSensitivities and rightEarSensitivities can't be empty");
-    if (frequencies.length != leftEarSensitivities.length ||
-        rightEarSensitivities.length != leftEarSensitivities.length)
-      throw ArgumentError(
-          "frequencies, leftEarSensitivities and rightEarSensitivities need to be of the same length");
-    if (startTime.isAfter(endTime))
-      throw ArgumentError("startTime must be equal or earlier than endTime");
-    if (_platformType == PlatformType.ANDROID)
-      throw UnsupportedError("writeAudiogram is not supported on Android");
+  Future<bool> writeAudiogram(List<double> frequencies, List<double> leftEarSensitivities, List<double> rightEarSensitivities, DateTime startTime, DateTime endTime, {Map<String, dynamic>? metadata}) async {
+    if (frequencies.isEmpty || leftEarSensitivities.isEmpty || rightEarSensitivities.isEmpty) throw ArgumentError("frequencies, leftEarSensitivities and rightEarSensitivities can't be empty");
+    if (frequencies.length != leftEarSensitivities.length || rightEarSensitivities.length != leftEarSensitivities.length) throw ArgumentError("frequencies, leftEarSensitivities and rightEarSensitivities need to be of the same length");
+    if (startTime.isAfter(endTime)) throw ArgumentError("startTime must be equal or earlier than endTime");
+    if (_platformType == PlatformType.ANDROID) throw UnsupportedError("writeAudiogram is not supported on Android");
     Map<String, dynamic> args = {
       'frequencies': frequencies,
       'leftEarSensitivities': leftEarSensitivities,
@@ -295,11 +279,7 @@ class HealthFactory {
   }
 
   /// Fetch a list of health data points based on [types].
-  Future<List<HealthDataPoint>> getHealthDataFromTypes(
-    DateTime startTime,
-    DateTime endTime,
-    List<HealthDataType> types,
-  ) async {
+  Future<List<HealthDataPoint>> getHealthDataFromTypes(DateTime startTime, DateTime endTime, List<HealthDataType> types) async {
     List<HealthDataPoint> dataPoints = [];
 
     for (var type in types) {
@@ -316,36 +296,25 @@ class HealthFactory {
   }
 
   /// Prepares a query, i.e. checks if the types are available, etc.
-  Future<List<HealthDataPoint>> _prepareQuery(
-      DateTime startTime, DateTime endTime, HealthDataType dataType) async {
+  Future<List<HealthDataPoint>> _prepareQuery(DateTime startTime, DateTime endTime, HealthDataType dataType) async {
     // Ask for device ID only once
-    _deviceId ??= _platformType == PlatformType.ANDROID
-        ? (await _deviceInfo.androidInfo).id
-        : (await _deviceInfo.iosInfo).identifierForVendor;
+    _deviceId ??= _platformType == PlatformType.ANDROID ? (await _deviceInfo.androidInfo).id : (await _deviceInfo.iosInfo).identifierForVendor;
 
     // If not implemented on platform, throw an exception
     if (!isDataTypeAvailable(dataType)) {
-      throw HealthException(
-          dataType, 'Not available on platform $_platformType');
+      throw HealthException(dataType, 'Not available on platform $_platformType');
     }
 
     // If BodyMassIndex is requested on Android, calculate this manually
-    if (dataType == HealthDataType.BODY_MASS_INDEX &&
-        _platformType == PlatformType.ANDROID) {
+    if (dataType == HealthDataType.BODY_MASS_INDEX && _platformType == PlatformType.ANDROID) {
       return _computeAndroidBMI(startTime, endTime);
     }
     return await _dataQuery(startTime, endTime, dataType);
   }
 
   /// The main function for fetching health data
-  Future<List<HealthDataPoint>> _dataQuery(
-      DateTime startTime, DateTime endTime, HealthDataType dataType) async {
-    final args = <String, dynamic>{
-      'dataTypeKey': dataType.typeToString(),
-      'dataUnitKey': _dataTypeToUnit[dataType]!.typeToString(),
-      'startTime': startTime.millisecondsSinceEpoch,
-      'endTime': endTime.millisecondsSinceEpoch
-    };
+  Future<List<HealthDataPoint>> _dataQuery(DateTime startTime, DateTime endTime, HealthDataType dataType) async {
+    final args = <String, dynamic>{'dataTypeKey': dataType.typeToString(), 'dataUnitKey': _dataTypeToUnit[dataType]!.typeToString(), 'startTime': startTime.millisecondsSinceEpoch, 'endTime': endTime.millisecondsSinceEpoch};
     final fetchedDataPoints = await _channel.invokeMethod('getData', args);
     if (fetchedDataPoints != null) {
       final mesg = <String, dynamic>{
@@ -416,10 +385,7 @@ class HealthFactory {
     DateTime startTime,
     DateTime endTime,
   ) async {
-    final args = <String, dynamic>{
-      'startTime': startTime.millisecondsSinceEpoch,
-      'endTime': endTime.millisecondsSinceEpoch
-    };
+    final args = <String, dynamic>{'startTime': startTime.millisecondsSinceEpoch, 'endTime': endTime.millisecondsSinceEpoch};
     final stepsCount = await _channel.invokeMethod<int?>(
       'getTotalStepsInInterval',
       args,
@@ -446,8 +412,7 @@ class HealthFactory {
       case HealthDataType.HEADACHE_SEVERE:
         return 4;
       default:
-        throw HealthException(type,
-            "HealthDataType was not aligned correctly - please report bug at https://github.com/cph-cachet/flutter-plugins/issues");
+        throw HealthException(type, "HealthDataType was not aligned correctly - please report bug at https://github.com/cph-cachet/flutter-plugins/issues");
     }
   }
 
@@ -474,11 +439,9 @@ class HealthFactory {
   }) async {
     // Check that value is on the current Platform
     if (_platformType == PlatformType.IOS && !_isOnIOS(activityType)) {
-      throw HealthException(activityType,
-          "Workout activity type $activityType is not supported on iOS");
+      throw HealthException(activityType, "Workout activity type $activityType is not supported on iOS");
     } else if (!_isOnAndroid(activityType)) {
-      throw HealthException(activityType,
-          "Workout activity type $activityType is not supported on Android");
+      throw HealthException(activityType, "Workout activity type $activityType is not supported on Android");
     }
     final args = <String, dynamic>{
       'activityType': activityType.typeToString(),


### PR DESCRIPTION
Two new functions which were discussed in https://github.com/cph-cachet/flutter-plugins/issues/642 and https://github.com/cph-cachet/flutter-plugins/issues/588

`delete()` - allows to delete a record of a given type in a period (Android and iOS)
`writeBloodPressure()` - allows to save blood pressure in one call (Android only, the current work on iOS)

Also updated README and `hasPermissions()` removed from the `requestAuthorization()` on Android because it prevents requesting authorization in some cases as described in the issue mentioned in the commit.