### PR TITLE
Added platform check to fix unintended exception

### DIFF
--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -476,7 +476,8 @@ class HealthFactory {
     if (_platformType == PlatformType.IOS && !_isOnIOS(activityType)) {
       throw HealthException(activityType,
           "Workout activity type $activityType is not supported on iOS");
-    } else if (!_isOnAndroid(activityType)) {
+    } else if (_platformType == PlatformType.ANDROID &&
+        !_isOnAndroid(activityType)) {
       throw HealthException(activityType,
           "Workout activity type $activityType is not supported on Android");
     }


### PR DESCRIPTION
Using a HealthWorkoutActivityType that is available on iOS, but not available on Android, currently leads to a HealthException.

This can be easily reproduced by starting a TRADITIONAL_STRENGTH_TRAINING on iOS, which should work, but causes an Android related exception. 

Fixed by checking for Android-Platform before throwing any Android-related exception.