### PR TITLE
audio_streamer update for noise_meter

### DIFF
--- a/packages/noise_meter/README.md
+++ b/packages/noise_meter/README.md
@@ -16,6 +16,31 @@ On *iOS* enable the following:
 * Capabilities > Background Modes > _Audio, AirPlay and Picture in Picture_
 * In the Runner Xcode project edit the _Info.plist_ file. Add an entry for _'Privacy - Microphone Usage Description'_
 
+When editing the Info.plist file manually, the entries needed are:
+```plist
+<key>NSMicrophoneUsageDescription</key>
+<string>YOUR DESCRIPTION</string>
+<key>UIBackgroundModes</key>
+<array>
+  <string>audio</string>
+</array>
+```
+* Edit the ```Podfile``` to include the permission for the microphone:
+
+```Podfile
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+
+    target.build_configurations.each do |config|
+      # for more infomation: https://github.com/BaseflowIT/flutter-permission-handler/blob/master/permission_handler/ios/Classes/PermissionHandlerEnums.h
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_MICROPHONE=1',]
+    end
+  end
+end
+```
 
 ## Usage
 ### Initialization

--- a/packages/noise_meter/README.md
+++ b/packages/noise_meter/README.md
@@ -27,7 +27,7 @@ When editing the Info.plist file manually, the entries needed are:
 ```
 * Edit the ```Podfile``` to include the permission for the microphone:
 
-```Podfile
+```ruby
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)

--- a/packages/noise_meter/README.md
+++ b/packages/noise_meter/README.md
@@ -17,7 +17,7 @@ On *iOS* enable the following:
 * In the Runner Xcode project edit the _Info.plist_ file. Add an entry for _'Privacy - Microphone Usage Description'_
 
 When editing the Info.plist file manually, the entries needed are:
-```plist
+```xml
 <key>NSMicrophoneUsageDescription</key>
 <string>YOUR DESCRIPTION</string>
 <key>UIBackgroundModes</key>

--- a/packages/noise_meter/pubspec.yaml
+++ b/packages/noise_meter/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  audio_streamer: ^2.1.0
+  audio_streamer: ^2.2.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Recently integrated the **noise_meter** into an app I was working on, it worked fine on android but never prompted for audio permission on iOS. Going through the documentation, I noticed the **audio_streamer** was a dependency. I delved deeper through the changelog for **audio_streamer** and noticed there has been an update in terms of **permission_handler** so I thought to reflect those changes on the **noise_meter** package. I look forward to your review. Thank you.