### PR TITLE
[Health] Match intl package to Flutter SDK

### DIFF
--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: any
   device_info_plus: ^8.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This fixes an incompatibility issue when the SDK and the specified intl package versions differ.
Currently it causes problems when switching between Flutter channels.

A more conservative option is to specify version ranges as suggested in [issue 692](https://github.com/cph-cachet/flutter-plugins/issues/692#issuecomment-1504900313), but that will require more maintenance.