### PR TITLE
add method `getDataWithLimit`

### DIFF
--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health
 description: Wrapper for HealthKit on iOS and Google Fit and Health Connect on Android.
-version: 6.0.0
+version: 6.0.0+1
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/health
 
 environment:


### PR DESCRIPTION
# Why are we making this pull request?
Original problem described: https://github.com/cph-cachet/flutter-plugins/pull/581

# Updates
Such as original plugins already contain `limit` parameter in ios native files, we could basically try to add this parameter to `getHealthDataFromTypes` function.

# How to use
```
  Future<bool> _ifAnyTypeCanBeRead({required List<HealthDataType> types}) async {
    //if this is an android device
    if (!Platform.isIOS) return true;

    final result = await _health.getDataWithLimit(types, 1);

    return result.isNotEmpty;
  }
```