### PR TITLE
Type check for category type

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -271,7 +271,7 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
         
         let sample: HKObject
         
-        if (unitLookUp(key: type) == HKUnit.init(from: "")) {
+        if (dataTypeLookUp(key: type) is HKCategoryType) {
             sample = HKCategorySample(type: dataTypeLookUp(key: type) as! HKCategoryType, value: Int(value), start: dateFrom, end: dateTo)
         } else {
             let quantity = HKQuantity(unit: unitDict[unit]!, doubleValue: value)


### PR DESCRIPTION
When trying to write sleep data on iOS, I received an error about trying to cast from categoryType to quantityType, this fixes that. I have tested writing data for weight and water with this change and those seem to be working with this change still