### PR TITLE
[health] Fix type mismatch in `getStepsHealthConnect`

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1299,7 +1299,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             result.success(stepsInInterval)
         } catch (e: Exception) {
             Log.i("FLUTTER_HEALTH::ERROR", "unable to return steps")
-            result.success(false)
+            result.success(null)
         }
     }
 


### PR DESCRIPTION
This fixes `type 'bool' is not a subtype of type 'int?' in type cast` when unable to return steps.