### PR TITLE
Update build.gradle

### DIFF
--- a/packages/pedometer/android/build.gradle
+++ b/packages/pedometer/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.pedometer'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Updated gradle to 1.5.20

Currently Pedometer can not be used with the latest version of flutter. Updating the gradle version fixes it.