### PR TITLE
[Health] Expose additional methods for HealthFactory

### DIFF
--- a/packages/health/android/build.gradle
+++ b/packages/health/android/build.gradle
@@ -25,14 +25,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
         minSdkVersion 28
-        targetSdkVersion 33
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -46,7 +46,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation("com.google.android.gms:play-services-fitness:21.1.0")
     implementation("com.google.android.gms:play-services-auth:20.2.0")
+    implementation("androidx.fragment:fragment:1.6.1")
 
     // The new health connect api
-    implementation("androidx.health.connect:connect-client:1.1.0-alpha03")
+    implementation("androidx.health.connect:connect-client:1.1.0-alpha04")
 }

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1392,6 +1392,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "useHealthConnectIfAvailable" -> useHealthConnectIfAvailable(call, result)
+            "checkAvailability" -> checkAvailability(call, result)
             "hasPermissions" -> hasPermissions(call, result)
             "requestAuthorization" -> requestAuthorization(call, result)
             "revokePermissions" -> revokePermissions(call, result)
@@ -1435,9 +1436,10 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     var healthConnectAvailable = false
     var healthConnectStatus = HealthConnectClient.SDK_UNAVAILABLE
 
-    fun checkAvailability() {
+    fun checkAvailability(call: MethodCall? = null, result: Result? = null) {
         healthConnectStatus = HealthConnectClient.getSdkStatus(context!!)
         healthConnectAvailable = healthConnectStatus == HealthConnectClient.SDK_AVAILABLE
+        result?.success(healthConnectAvailable)
     }
 
     fun useHealthConnectIfAvailable(call: MethodCall, result: Result) {

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1393,6 +1393,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         when (call.method) {
             "useHealthConnectIfAvailable" -> useHealthConnectIfAvailable(call, result)
             "checkAvailability" -> checkAvailability(call, result)
+            "openSystemSettings" -> openSystemSettings(call, result)
             "hasPermissions" -> hasPermissions(call, result)
             "requestAuthorization" -> requestAuthorization(call, result)
             "revokePermissions" -> revokePermissions(call, result)
@@ -1440,6 +1441,18 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         healthConnectStatus = HealthConnectClient.getSdkStatus(context!!)
         healthConnectAvailable = healthConnectStatus == HealthConnectClient.SDK_AVAILABLE
         result?.success(healthConnectAvailable)
+    }
+
+    fun openSystemSettings(call: MethodCall, result: Result) {
+        try {
+            val intent = Intent()
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.action = HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS
+            context?.startActivity(intent)
+            result.success(true)
+        } catch (e: Throwable) {
+            result.error("UNABLE_TO_START_ACTIVITY", e.message, e)
+        }
     }
 
     fun useHealthConnectIfAvailable(call: MethodCall, result: Result) {

--- a/packages/health/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/health/example/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,10 @@
     <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE"/>
     <uses-permission android:name="android.permission.health.READ_RESPIRATORY_RATE"/>
     <uses-permission android:name="android.permission.health.WRITE_RESPIRATORY_RATE"/>
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE_VARIABILITY"/>
+    <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY"/>
+    <uses-permission android:name="android.permission.health.READ_LEAN_BODY_MASS"/>
+    <uses-permission android:name="android.permission.health.WRITE_LEAN_BODY_MASS"/>
 
 
     <application android:label="health_example"
@@ -77,6 +81,12 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+
+            <!-- Health Permission handling for Android 14 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE"/>
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS"/>
             </intent-filter>
         </activity>
         <meta-data android:name="flutterEmbedding"

--- a/packages/health/example/android/app/src/main/kotlin/cachet/plugins/example_app/MainActivity.kt
+++ b/packages/health/example/android/app/src/main/kotlin/cachet/plugins/example_app/MainActivity.kt
@@ -2,7 +2,7 @@ package cachet.plugins.example_app
 
 import android.os.Bundle
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity: FlutterFragmentActivity() {
 }

--- a/packages/health/example/lib/main.dart
+++ b/packages/health/example/lib/main.dart
@@ -244,6 +244,22 @@ class _HealthAppState extends State<HealthApp> {
     }
   }
 
+  Future<void> openSettings() async {
+    try {
+      await health.openSystemSettings();
+    } catch (error) {
+      print("Caught exception in openSettings: $error");
+    }
+  }
+
+  Future<void> checkAvailability() async {
+    try {
+      await health.checkAvailability();
+    } catch (error) {
+      print("Caught exception in checkAvailability: $error");
+    }
+  }
+
   Widget _contentFetchingData() {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -408,6 +424,20 @@ class _HealthAppState extends State<HealthApp> {
                   TextButton(
                       onPressed: revokeAccess,
                       child: Text("Revoke Access",
+                          style: TextStyle(color: Colors.white)),
+                      style: ButtonStyle(
+                          backgroundColor:
+                              MaterialStatePropertyAll(Colors.blue))),
+                  TextButton(
+                      onPressed: checkAvailability,
+                      child: Text("Check availability",
+                          style: TextStyle(color: Colors.white)),
+                      style: ButtonStyle(
+                          backgroundColor:
+                              MaterialStatePropertyAll(Colors.blue))),
+                  TextButton(
+                      onPressed: openAppSettings,
+                      child: Text("Open settings",
                           style: TextStyle(color: Colors.white)),
                       style: ButtonStyle(
                           backgroundColor:

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -52,6 +52,10 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
   let SLEEP_AWAKE = "SLEEP_AWAKE"
   let SLEEP_DEEP = "SLEEP_DEEP"
   let SLEEP_REM = "SLEEP_REM"
+  let LEAN_BODY_MASS = "LEAN_BODY_MASS"
+  let MOVE_TIME = "MOVE_TIME"
+  let STAND_HOUR = "STAND_HOUR"
+  let STAND_TIME = "STAND_TIME"
 
   let EXERCISE_TIME = "EXERCISE_TIME"
   let WORKOUT = "WORKOUT"
@@ -237,6 +241,9 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
     else {
       throw PluginError(message: "Invalid Arguments!")
     }
+      
+    // Sharing those data is not allowed.
+    let typesExcludedFromWrite = [MOVE_TIME, STAND_HOUR, STAND_TIME]
 
     var typesToRead = Set<HKSampleType>()
     var typesToWrite = Set<HKSampleType>()
@@ -247,10 +254,10 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
       case 0:
         typesToRead.insert(dataType)
       case 1:
-        typesToWrite.insert(dataType)
+        if !typesExcludedFromWrite.contains(key) { typesToWrite.insert(dataType) }
       default:
         typesToRead.insert(dataType)
-        typesToWrite.insert(dataType)
+        if !typesExcludedFromWrite.contains(key) { typesToWrite.insert(dataType) }
       }
     }
 
@@ -915,12 +922,22 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
       dataTypesDict[SLEEP_AWAKE] = HKSampleType.categoryType(forIdentifier: .sleepAnalysis)!
       dataTypesDict[SLEEP_DEEP] = HKSampleType.categoryType(forIdentifier: .sleepAnalysis)!
       dataTypesDict[SLEEP_REM] = HKSampleType.categoryType(forIdentifier: .sleepAnalysis)!
+      dataTypesDict[LEAN_BODY_MASS] = HKSampleType.quantityType(forIdentifier: .leanBodyMass)!
+    
+      dataTypesDict[STAND_HOUR] = HKSampleType.categoryType(forIdentifier: .appleStandHour)!
+      dataTypesDict[STAND_TIME] = HKSampleType.quantityType(forIdentifier: .appleStandTime)!
 
       dataTypesDict[EXERCISE_TIME] = HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!
       dataTypesDict[WORKOUT] = HKSampleType.workoutType()
 
       healthDataTypes = Array(dataTypesDict.values)
     }
+      
+    // Set up move time, requires iOS 14.5
+    if #available(iOS 14.5, *) {
+      dataTypesDict[MOVE_TIME] = HKSampleType.quantityType(forIdentifier: .appleMoveTime)!
+    }
+      
     // Set up heart rate data types specific to the apple watch, requires iOS 12
     if #available(iOS 12.2, *) {
       dataTypesDict[HIGH_HEART_RATE_EVENT] = HKSampleType.categoryType(

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -136,6 +136,10 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
     else if call.method.elementsEqual("requestAuthorization") {
       try! requestAuthorization(call: call, result: result)
     }
+      
+    else if call.method.elementsEqual("openSystemSettings") {
+      openSystemSettings(call: call, result: result)
+    }
 
     /// Handle getData
     else if call.method.elementsEqual("getData") {
@@ -181,6 +185,10 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
   func checkIfHealthDataAvailable(call: FlutterMethodCall, result: @escaping FlutterResult) {
     result(HKHealthStore.isHealthDataAvailable())
+  }
+    
+  func openSystemSettings(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    UIApplication.shared.open(URL(string: "x-apple-health://")!)
   }
 
   func hasPermissions(call: FlutterMethodCall, result: @escaping FlutterResult) throws {

--- a/packages/health/lib/src/data_types.dart
+++ b/packages/health/lib/src/data_types.dart
@@ -29,7 +29,6 @@ enum HealthDataType {
   WEIGHT,
   DISTANCE_WALKING_RUNNING,
   FLIGHTS_CLIMBED,
-  MOVE_MINUTES,
   DISTANCE_DELTA,
   MINDFULNESS,
   WATER,
@@ -48,6 +47,10 @@ enum HealthDataType {
   HEADACHE_MODERATE,
   HEADACHE_SEVERE,
   HEADACHE_UNSPECIFIED,
+  LEAN_BODY_MASS,
+  MOVE_TIME,
+  STAND_HOUR,
+  STAND_TIME,
 
   // Heart Rate events (specific to Apple Watch)
   HIGH_HEART_RATE_EVENT,
@@ -112,6 +115,10 @@ const List<HealthDataType> _dataTypeKeysIOS = [
   HealthDataType.HEADACHE_SEVERE,
   HealthDataType.HEADACHE_UNSPECIFIED,
   HealthDataType.ELECTROCARDIOGRAM,
+  HealthDataType.LEAN_BODY_MASS,
+  HealthDataType.MOVE_TIME,
+  HealthDataType.STAND_HOUR,
+  HealthDataType.STAND_TIME,
 ];
 
 /// List of data types available on Android
@@ -125,10 +132,10 @@ const List<HealthDataType> _dataTypeKeysAndroid = [
   HealthDataType.BODY_MASS_INDEX,
   HealthDataType.BODY_TEMPERATURE,
   HealthDataType.HEART_RATE,
+  HealthDataType.HEART_RATE_VARIABILITY_SDNN,
   HealthDataType.HEIGHT,
   HealthDataType.STEPS,
   HealthDataType.WEIGHT,
-  HealthDataType.MOVE_MINUTES,
   HealthDataType.DISTANCE_DELTA,
   HealthDataType.SLEEP_AWAKE,
   HealthDataType.SLEEP_ASLEEP,
@@ -143,6 +150,7 @@ const List<HealthDataType> _dataTypeKeysAndroid = [
   HealthDataType.FLIGHTS_CLIMBED,
   HealthDataType.BASAL_ENERGY_BURNED,
   HealthDataType.RESPIRATORY_RATE,
+  HealthDataType.LEAN_BODY_MASS,
 ];
 
 /// Maps a [HealthDataType] to a [HealthDataUnit].
@@ -174,8 +182,8 @@ const Map<HealthDataType, HealthDataUnit> _dataTypeToUnit = {
   HealthDataType.WEIGHT: HealthDataUnit.KILOGRAM,
   HealthDataType.DISTANCE_WALKING_RUNNING: HealthDataUnit.METER,
   HealthDataType.FLIGHTS_CLIMBED: HealthDataUnit.COUNT,
-  HealthDataType.MOVE_MINUTES: HealthDataUnit.MINUTE,
   HealthDataType.DISTANCE_DELTA: HealthDataUnit.METER,
+  HealthDataType.LEAN_BODY_MASS: HealthDataUnit.KILOGRAM,
 
   HealthDataType.WATER: HealthDataUnit.LITER,
   HealthDataType.SLEEP_IN_BED: HealthDataUnit.MINUTE,
@@ -196,6 +204,10 @@ const Map<HealthDataType, HealthDataUnit> _dataTypeToUnit = {
   HealthDataType.HEADACHE_MODERATE: HealthDataUnit.MINUTE,
   HealthDataType.HEADACHE_SEVERE: HealthDataUnit.MINUTE,
   HealthDataType.HEADACHE_UNSPECIFIED: HealthDataUnit.MINUTE,
+
+  HealthDataType.MOVE_TIME: HealthDataUnit.MINUTE,
+  HealthDataType.STAND_HOUR: HealthDataUnit.HOUR,
+  HealthDataType.STAND_TIME: HealthDataUnit.MINUTE,
 
   // Heart Rate events (specific to Apple Watch)
   HealthDataType.HIGH_HEART_RATE_EVENT: HealthDataUnit.NO_UNIT,
@@ -463,8 +475,7 @@ enum ElectrocardiogramClassification {
 }
 
 /// Extension to assign numbers to [ElectrocardiogramClassification]s
-extension ElectrocardiogramClassificationValue
-    on ElectrocardiogramClassification {
+extension ElectrocardiogramClassificationValue on ElectrocardiogramClassification {
   int get value {
     switch (this) {
       case ElectrocardiogramClassification.NOT_SET:

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -107,6 +107,15 @@ class HealthFactory {
     return result ?? false;
   }
 
+  /// Opens native system settings for:
+  /// - Health on iOS 
+  /// - Health Connect on Android
+  /// 
+  /// Throws if the application is not installed on the device.
+  Future<void> openSystemSettings() async {
+    await _channel.invokeMethod('openSystemSettings');
+  }
+
   /// Requests permissions to access data types in Apple Health or Google Fit.
   ///
   /// Returns true if successful, false otherwise

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -1,5 +1,18 @@
 part of health;
 
+extension _PlatformSpecificTypesExtension on List<HealthDataType> {
+  /// Filters out platform specific health data types.
+  List<HealthDataType> platformSpecific(PlatformType platformType) {
+    return this..removeWhere((type) => !_isTypeAvailable(type, platformType));
+  }
+
+  bool _isTypeAvailable(HealthDataType type, PlatformType platformType) {
+    return platformType == PlatformType.ANDROID
+        ? _dataTypeKeysAndroid.contains(type)
+        : _dataTypeKeysIOS.contains(type);
+  }
+}
+
 /// Main class for the Plugin.
 ///
 /// The plugin supports:
@@ -108,9 +121,9 @@ class HealthFactory {
   }
 
   /// Opens native system settings for:
-  /// - Health on iOS 
+  /// - Health on iOS
   /// - Health Connect on Android
-  /// 
+  ///
   /// Throws if the application is not installed on the device.
   Future<void> openSystemSettings() async {
     await _channel.invokeMethod('openSystemSettings');
@@ -158,7 +171,8 @@ class HealthFactory {
       }
     }
 
-    final mTypes = List<HealthDataType>.from(types, growable: true);
+    final mTypes = List<HealthDataType>.from(types, growable: true)
+        .platformSpecific(_platformType);
     final mPermissions = permissions == null
         ? List<int>.filled(types.length, HealthDataAccess.READ.index,
             growable: true)
@@ -433,7 +447,7 @@ class HealthFactory {
       DateTime startTime, DateTime endTime, List<HealthDataType> types) async {
     List<HealthDataPoint> dataPoints = [];
 
-    for (var type in types) {
+    for (var type in types.platformSpecific(_platformType)) {
       final result = await _prepareQuery(startTime, endTime, type);
       dataPoints.addAll(result);
     }

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -95,6 +95,18 @@ class HealthFactory {
     }
   }
 
+  /// Checks the availability of Health Connect on Android platform.
+  ///
+  /// Returns a bool indicating whether Health Connect is available.
+  ///
+  /// On other platforms than Android it returns always true.
+  Future<bool> checkAvailability() async {
+    if (!Platform.isAndroid) return true;
+
+    final result = await _channel.invokeMethod<bool>('checkAvailability');
+    return result ?? false;
+  }
+
   /// Requests permissions to access data types in Apple Health or Google Fit.
   ///
   /// Returns true if successful, false otherwise

--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.18.0
-  device_info_plus: ^9.0.0
+  intl: ^0.18.1
+  device_info_plus: ^9.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Added ability to open native settings for Health and Health connect apps on iOS & Android
- Added ability to checkAvailability of Health Connect at any time

Currently it was only checked in onAttachedToEngine plugin method (once on initialization). Then after the user downloaded Health Connect, it was impossible to refresh the Health Connect availability status.

Steps to reproduce the current behavior:
1) Uninstall Health Connect
2) Call `HealthFactory(useHealthConnectIfAvailable: true).requestAuthorization(...);` - it will fallback to Google Fit.
3) Download Health Connect
4) Call `HealthFactory(useHealthConnectIfAvailable: true).requestAuthorization(...);` - it will fallback to Google Fit even tho we already have Health Connect.

This PR allows to call checkAvalability() before requesting permission so that we won't fallback to Google Fit when we actually have Health Connect installed