### PR TITLE
Support pagination in health connect

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1691,15 +1691,39 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         val healthConnectData = mutableListOf<Map<String, Any?>>()
         scope.launch {
             MapToHCType[dataType]?.let { classType ->
-                val request = ReadRecordsRequest(
+                val records = mutableListOf<Record>()
+
+                // Set up the initial request to read health records with specified parameters
+                var request = ReadRecordsRequest(
                     recordType = classType,
+                    // Define the maximum amount of data that HealthConnect can return in a single request
+                    pageSize = 5000,
                     timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
                 )
-                val response = healthConnectClient.readRecords(request)
+                
+                var response = healthConnectClient.readRecords(request)
+                var pageToken = response.pageToken
+                
+                // Add the records from the initial response to the records list
+                records.addAll(response.records)
+
+                // Continue making requests and fetching records while there is a page token
+                while (pageToken != null) {
+                    request = ReadRecordsRequest(
+                        recordType = classType,
+                        pageSize = 5000,
+                        timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
+                        pageToken = pageToken
+                    )
+                    response = healthConnectClient.readRecords(request)
+
+                    pageToken = response.pageToken
+                    records.addAll(response.records)
+                }
 
                 // Workout needs distance and total calories burned too
                 if (dataType == WORKOUT) {
-                    for (rec in response.records) {
+                    for (rec in records) {
                         val record = rec as ExerciseSessionRecord
                         val distanceRequest = healthConnectClient.readRecords(
                             ReadRecordsRequest(
@@ -1752,7 +1776,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                     }
                     // Filter sleep stages for requested stage
                 } else if (classType == SleepStageRecord::class) {
-                    for (rec in response.records) {
+                    for (rec in records) {
                         if (rec is SleepStageRecord) {
                             if (dataType == MapSleepStageToType[rec.stage]) {
                                 healthConnectData.addAll(convertRecord(rec, dataType))
@@ -1760,7 +1784,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                         }
                     }
                 } else {
-                    for (rec in response.records) {
+                    for (rec in records) {
                         healthConnectData.addAll(convertRecord(rec, dataType))
                     }
                 }

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1697,7 +1697,6 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                 var request = ReadRecordsRequest(
                     recordType = classType,
                     // Define the maximum amount of data that HealthConnect can return in a single request
-                    pageSize = 5000,
                     timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
                 )
                 
@@ -1708,10 +1707,9 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                 records.addAll(response.records)
 
                 // Continue making requests and fetching records while there is a page token
-                while (pageToken != null) {
+                while (!pageToken.isNullOrEmpty()) {
                     request = ReadRecordsRequest(
                         recordType = classType,
-                        pageSize = 5000,
                         timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
                         pageToken = pageToken
                     )


### PR DESCRIPTION
Issues have been reported at https://github.com/cph-cachet/flutter-plugins/issues/833, indicating that there is a limit on the amount of data that Health Connect can return due to the missing implementation of a pagination system.

This pull request contains a fix for that issue.