### PR TITLE
Upgrade to AGP 8 and Add Namespace Support for Health Module

### DIFF
--- a/packages/health/android/build.gradle
+++ b/packages/health/android/build.gradle
@@ -2,14 +2,14 @@ group 'cachet.plugins.health'
 version '1.2'
 
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -27,6 +27,15 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 34
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -38,6 +47,7 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    namespace "cachet.plugins.health"
 }
 
 dependencies {

--- a/packages/health/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/health/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Summary

This PR introduces necessary updates to the health module in the flutter_plugins package, ensuring compatibility with AGP 8. It also addresses the issue of the missing namespace declaration, which is required for the latest Android Gradle Plugin.

# Changes Made

Updated the Gradle version to 8, making the module compatible with recent Android development standards.
Added the namespace declaration in the build.gradle file of the health module to meet the requirements of the latest Android Gradle Plugin.

# Testing

I have manually verified the functionality of the changes. This verification involved installing the updated health module using this PR's code and successfully retrieving weight and body fat percentage data from the Google Fit API. 