### PR TITLE
Update build.gradle.

### DIFF
--- a/packages/audio_streamer/example/android/app/build.gradle
+++ b/packages/audio_streamer/example/android/app/build.gradle
@@ -56,6 +56,9 @@ android {
     lint {
         disable 'InvalidPackage'
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
     namespace 'plugins.cachet.audio_streamer_example'
 }
 


### PR DESCRIPTION
Update  build.gradle to make audio_streamer library android example project build pass.