### PR TITLE
fix minSdkVersion in build.gradle of audio_streamer

### DIFF
--- a/packages/audio_streamer/android/build.gradle
+++ b/packages/audio_streamer/android/build.gradle
@@ -39,7 +39,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
revert it from 28 into 16

`
> Manifest merger failed : uses-sdk:minSdkVersion 21 cannot be smaller than version 28 declared in library [:audio_streamer] /xxx/build/audio_streamer/intermediates/merged_manifest/debug/AndroidManifest.xml as the library might be using APIs not available in 21

`