### PR TITLE
Add uuid, wasUserEntered data from Apple HealthKit

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -599,6 +599,8 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "wasUserEntered": sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool ?? false,
+                        
                     ]
                 }
                 DispatchQueue.main.async {
@@ -667,6 +669,8 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "wasUserEntered": sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool,
+                        "duration": sample.duration,
                     ]
                 }
                 

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -12,7 +12,7 @@ class HealthDataPoint {
   String _deviceId;
   String _sourceId;
   String _sourceName;
-  String _uuid;
+  String? _uuid;
   bool? _wasUserEntered;
 
   HealthDataPoint(
@@ -144,7 +144,7 @@ class HealthDataPoint {
   String get sourceName => _sourceName;
 
   /// The uniq identifier of health data from Apple HealthKit
-  String get uuid => _uuid;
+  String? get uuid => _uuid;
 
   // HKMetadataKeyWasUserEntered from AppleHealthKit
   bool? get wasUserEntered => _wasUserEntered;

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -12,6 +12,8 @@ class HealthDataPoint {
   String _deviceId;
   String _sourceId;
   String _sourceName;
+  String _uuid;
+  bool? _wasUserEntered;
 
   HealthDataPoint(
       this._value,
@@ -22,7 +24,9 @@ class HealthDataPoint {
       this._platform,
       this._deviceId,
       this._sourceId,
-      this._sourceName) {
+      this._sourceName,
+      this._uuid,
+      this._wasUserEntered) {
     // set the value to minutes rather than the category
     // returned by the native API
     if (type == HealthDataType.MINDFULNESS ||
@@ -72,7 +76,9 @@ class HealthDataPoint {
             .indexOf(json['platform_type'])],
         json['device_id'],
         json['source_id'],
-        json['source_name']);
+        json['source_name'],
+        json['uuid'],
+        json['wasUserEntered']);
   }
 
   /// Converts the [HealthDataPoint] to a json object
@@ -85,7 +91,9 @@ class HealthDataPoint {
         'platform_type': PlatformTypeJsonValue[platform],
         'device_id': deviceId,
         'source_id': sourceId,
-        'source_name': sourceName
+        'source_name': sourceName,
+        'uuid': uuid,
+        'wasUserEntered': wasUserEntered,
       };
 
   @override
@@ -98,7 +106,9 @@ class HealthDataPoint {
     platform: $platform,
     deviceId: $deviceId,
     sourceId: $sourceId,
-    sourceName: $sourceName""";
+    sourceName: $sourceName,
+    uuid: $uuid,
+    wasUserEntered: $wasUserEntered""";
 
   /// The quantity value of the data point
   HealthValue get value => _value;
@@ -133,6 +143,12 @@ class HealthDataPoint {
   /// The name of the source from which the data point was fetched.
   String get sourceName => _sourceName;
 
+  /// The uniq identifier of health data from Apple HealthKit
+  String get uuid => _uuid;
+
+  // HKMetadataKeyWasUserEntered from AppleHealthKit
+  bool? get wasUserEntered => _wasUserEntered;
+
   @override
   bool operator ==(Object o) {
     return o is HealthDataPoint &&
@@ -144,10 +160,11 @@ class HealthDataPoint {
         this.platform == o.platform &&
         this.deviceId == o.deviceId &&
         this.sourceId == o.sourceId &&
-        this.sourceName == o.sourceName;
+        this.sourceName == o.sourceName &&
+        this.wasUserEntered == o.wasUserEntered;
   }
 
   @override
   int get hashCode => Object.hash(value, unit, dateFrom, dateTo, type, platform,
-      deviceId, sourceId, sourceName);
+      deviceId, sourceId, sourceName, wasUserEntered);
 }

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -550,8 +550,8 @@ class HealthFactory {
       final DateTime to = DateTime.fromMillisecondsSinceEpoch(e['date_to']);
       final String sourceId = e["source_id"];
       final String sourceName = e["source_name"];
-      final String uuid = e["uuid"];
-      final String wasUserEntered = e["wasUserEntered"];
+      final String? uuid = e["uuid"];
+      final bool? wasUserEntered = e["wasUserEntered"];
       return HealthDataPoint(
         value,
         dataType,

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -209,7 +209,9 @@ class HealthFactory {
           _platformType,
           _deviceId!,
           '',
-          '');
+          '',
+          '',
+          null);
 
       bmiHealthPoints.add(x);
     }
@@ -548,6 +550,8 @@ class HealthFactory {
       final DateTime to = DateTime.fromMillisecondsSinceEpoch(e['date_to']);
       final String sourceId = e["source_id"];
       final String sourceName = e["source_name"];
+      final String uuid = e["uuid"];
+      final String wasUserEntered = e["wasUserEntered"];
       return HealthDataPoint(
         value,
         dataType,
@@ -558,6 +562,8 @@ class HealthFactory {
         device,
         sourceId,
         sourceName,
+        uuid,
+        wasUserEntered,
       );
     }).toList();
 

--- a/packages/health/lib/src/health_value_types.dart
+++ b/packages/health/lib/src/health_value_types.dart
@@ -106,6 +106,7 @@ class WorkoutHealthValue extends HealthValue {
   int? _totalEnergyBurned;
   HealthDataUnit? _totalEnergyBurnedUnit;
   int? _totalDistance;
+  int? _duration;
   HealthDataUnit? _totalDistanceUnit;
 
   WorkoutHealthValue(
@@ -113,7 +114,8 @@ class WorkoutHealthValue extends HealthValue {
       this._totalEnergyBurned,
       this._totalEnergyBurnedUnit,
       this._totalDistance,
-      this._totalDistanceUnit);
+      this._totalDistanceUnit,
+      this._duration);
 
   /// The type of the workout.
   HealthWorkoutActivityType get workoutActivityType => _workoutActivityType;
@@ -134,6 +136,10 @@ class WorkoutHealthValue extends HealthValue {
   /// Might not be available for all workouts.
   HealthDataUnit? get totalDistanceUnit => _totalDistanceUnit;
 
+  /// The unit of workout duration.
+  /// Might not be available for all workouts.
+  int? get duration => _duration;
+
   factory WorkoutHealthValue.fromJson(json) {
     return WorkoutHealthValue(
         HealthWorkoutActivityType.values.firstWhere(
@@ -151,7 +157,8 @@ class WorkoutHealthValue extends HealthValue {
         json['totalDistanceUnit'] != null
             ? HealthDataUnit.values.firstWhere(
                 (element) => element.name == json['totalDistanceUnit'])
-            : null);
+            : null,
+        json['duration'] != null ? (json['duration'] as num).toInt() : null);
   }
 
   @override
@@ -161,6 +168,7 @@ class WorkoutHealthValue extends HealthValue {
         'totalEnergyBurnedUnit': _totalEnergyBurnedUnit?.name,
         'totalDistance': _totalDistance,
         'totalDistanceUnit': _totalDistanceUnit?.name,
+        'duration': _duration,
       };
 
   @override
@@ -169,7 +177,8 @@ class WorkoutHealthValue extends HealthValue {
            totalEnergyBurned: $totalEnergyBurned,
            totalEnergyBurnedUnit: ${totalEnergyBurnedUnit?.name},
            totalDistance: $totalDistance,
-           totalDistanceUnit: ${totalDistanceUnit?.name}""";
+           totalDistanceUnit: ${totalDistanceUnit?.name}
+           duration: ${duration}""";
   }
 
   @override
@@ -179,12 +188,13 @@ class WorkoutHealthValue extends HealthValue {
         this.totalEnergyBurned == o.totalEnergyBurned &&
         this.totalEnergyBurnedUnit == o.totalEnergyBurnedUnit &&
         this.totalDistance == o.totalDistance &&
-        this.totalDistanceUnit == o.totalDistanceUnit;
+        this.totalDistanceUnit == o.totalDistanceUnit &&
+        this.duration == o.duration;
   }
 
   @override
   int get hashCode => Object.hash(workoutActivityType, totalEnergyBurned,
-      totalEnergyBurnedUnit, totalDistance, totalDistanceUnit);
+      totalEnergyBurnedUnit, totalDistance, totalDistanceUnit, duration);
 }
 
 /// A [HealthValue] object for ECGs


### PR DESCRIPTION
For the Apple Health Kit, `UUID` is required to distinguish if data was modified later or not.
Also added is data added by hand or not.

Closes #768
