### PR TITLE
feat(Health): add property to indicate whether a data point was manually entered by the user

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1154,6 +1154,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                                         )
                             ),
                     "source_id" to dataPoint.originalDataSource.streamIdentifier,
+                    "user_entered" to (dataPoint.originalDataSource.streamName == "user_input"),
                 )
             }
             Handler(context!!.mainLooper).run { result.success(healthData) }

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -599,6 +599,7 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "user_entered": sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool ?? false,
                     ]
                 }
                 DispatchQueue.main.async {

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -12,6 +12,7 @@ class HealthDataPoint {
   String _deviceId;
   String _sourceId;
   String _sourceName;
+  bool _isUserEntered;
 
   HealthDataPoint(
       this._value,
@@ -22,7 +23,8 @@ class HealthDataPoint {
       this._platform,
       this._deviceId,
       this._sourceId,
-      this._sourceName) {
+      this._sourceName,
+      this._isUserEntered) {
     // set the value to minutes rather than the category
     // returned by the native API
     if (type == HealthDataType.MINDFULNESS ||
@@ -72,7 +74,8 @@ class HealthDataPoint {
             .indexOf(json['platform_type'])],
         json['device_id'],
         json['source_id'],
-        json['source_name']);
+        json['source_name'],
+        json['user_entered']);
   }
 
   /// Converts the [HealthDataPoint] to a json object
@@ -85,7 +88,8 @@ class HealthDataPoint {
         'platform_type': PlatformTypeJsonValue[platform],
         'device_id': deviceId,
         'source_id': sourceId,
-        'source_name': sourceName
+        'source_name': sourceName,
+        'user_entered': _isUserEntered
       };
 
   @override
@@ -98,7 +102,8 @@ class HealthDataPoint {
     platform: $platform,
     deviceId: $deviceId,
     sourceId: $sourceId,
-    sourceName: $sourceName""";
+    sourceName: $sourceName,
+    userEntered: $_isUserEntered""";
 
   /// The quantity value of the data point
   HealthValue get value => _value;
@@ -133,6 +138,9 @@ class HealthDataPoint {
   /// The name of the source from which the data point was fetched.
   String get sourceName => _sourceName;
 
+  /// Whether the data point was manually entered by the user.
+  bool get isUserEntered => _isUserEntered;
+
   @override
   bool operator ==(Object o) {
     return o is HealthDataPoint &&
@@ -144,10 +152,11 @@ class HealthDataPoint {
         this.platform == o.platform &&
         this.deviceId == o.deviceId &&
         this.sourceId == o.sourceId &&
-        this.sourceName == o.sourceName;
+        this.sourceName == o.sourceName &&
+        this._isUserEntered == o._isUserEntered;
   }
 
   @override
   int get hashCode => Object.hash(value, unit, dateFrom, dateTo, type, platform,
-      deviceId, sourceId, sourceName);
+      deviceId, sourceId, sourceName, isUserEntered);
 }

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -200,6 +200,8 @@ class HealthFactory {
       final bmiValue =
           (weights[i].value as NumericHealthValue).numericValue.toDouble() /
               (h * h);
+      final isUserEntered =
+          heights.last.isUserEntered || weights[i].isUserEntered;
       final x = HealthDataPoint(
           NumericHealthValue(bmiValue),
           dataType,
@@ -209,7 +211,8 @@ class HealthFactory {
           _platformType,
           _deviceId!,
           '',
-          '');
+          '',
+          isUserEntered);
 
       bmiHealthPoints.add(x);
     }
@@ -548,6 +551,7 @@ class HealthFactory {
       final DateTime to = DateTime.fromMillisecondsSinceEpoch(e['date_to']);
       final String sourceId = e["source_id"];
       final String sourceName = e["source_name"];
+      final bool userEntered = e["user_entered"];
       return HealthDataPoint(
         value,
         dataType,
@@ -558,6 +562,7 @@ class HealthFactory {
         device,
         sourceId,
         sourceName,
+        userEntered,
       );
     }).toList();
 


### PR DESCRIPTION
Adds a property to HealthDataPoint that indicates whether a data point was manually entered by the user:
- **(Android)** Adds a key named 'user_entered' to the map that is created from each extracted Fitness data point. This key contains a bool value that indicates whether the data point was manually entered by the user or not.
- **(iOS)** Adds a key named 'user_entered' to the map that is created from each extracted Health data sample. This key contains a bool value that indicates whether the data sample was manually entered by the user or not.
- Adds a property named '_isUserEntered' to the HealthDataPoint model to indicate whether the data point was manually entered by the user.
- Adds 'userEntered' property to all HealthDataPoint object creations in HealthFactory.

Closes #684 , closes #670 , closes #590 , closes #396 , closes #293 