### PR TITLE
[health] Fixed SleepSessionRecord stage error

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -2272,8 +2272,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                     "date_to" to record.endTime.toEpochMilli(),
                     "value" to ChronoUnit.MINUTES.between(record.startTime, record.endTime),
                     "source_id" to "",
-                    "source_name" to metadata.dataOrigin.packageName,
-                    "stage" to if (record.stages.isNotEmpty()) record.stages[0] else SleepSessionRecord.STAGE_TYPE_UNKNOWN,
+                    "source_name" to metadata.dataOrigin.packageName,                    
                 ),
             )
             is RestingHeartRateRecord -> return listOf(


### PR DESCRIPTION
Step to reproduce:
```
HealthFactory health = HealthFactory(
  useHealthConnectIfAvailable: true,
);

var sleepDataHC = await health.getHealthDataFromTypes(
      sleepStart,
      sleepEnd,
      [
        HealthDataType.SLEEP_SESSION,
      ],
    );
```

Result:
```
 java.lang.IllegalArgumentException: Unsupported value: 'androidx.health.connect.client.records.SleepSessionRecord$Stage@c063c16c' of type 'class androidx.health.connect.client.records.SleepSessionRecord$Stage'
```