### PR TITLE
fix: getting stuck in health connect mode

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -2461,7 +2461,8 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         }
 
         fun useHealthConnectIfAvailable(call: MethodCall, result: Result) {
-                useHealthConnectIfAvailable = true
+                val useHealthConnect = call.argument<Boolean>("useHealthConnect")!!
+                useHealthConnectIfAvailable = useHealthConnect
                 result.success(null)
         }
 

--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -59,9 +59,9 @@ class Health {
         : (await _deviceInfo.iosInfo).identifierForVendor;
 
     _useHealthConnectIfAvailable = useHealthConnectIfAvailable;
-    if (_useHealthConnectIfAvailable) {
-      await _channel.invokeMethod('useHealthConnectIfAvailable');
-    }
+    await _channel.invokeMethod('useHealthConnectIfAvailable', {
+      "useHealthConnect": useHealthConnectIfAvailable,
+    });
   }
 
   /// Is this plugin using Health Connect (true) or Google Fit (false)?


### PR DESCRIPTION
Fixed an issue where when useHealthConnectIfAvailable is set to true it is unable to be set back to false. This locks the user into health connect even after attempting to set it back to back to false.

Fix for [Issue 969](https://github.com/cph-cachet/flutter-plugins/issues/969) 