### PR TITLE
[Health] Do not invoke method channel API when useHealthConnectIfAvailable is true on iOS

### DIFF
--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -54,13 +54,12 @@ class Health {
   /// If [useHealthConnectIfAvailable] is true, Google Health Connect on
   /// Android will be used. Has no effect on iOS.
   Future<void> configure({bool useHealthConnectIfAvailable = false}) async {
-    _deviceId ??= Platform.isAndroid
-        ? (await _deviceInfo.androidInfo).id
-        : (await _deviceInfo.iosInfo).identifierForVendor;
-
-    _useHealthConnectIfAvailable = useHealthConnectIfAvailable;
-    if (_useHealthConnectIfAvailable) {
+    if (Platform.isAndroid) {
+      _deviceId = (await _deviceInfo.androidInfo).id;
+      _useHealthConnectIfAvailable = useHealthConnectIfAvailable;
       await _channel.invokeMethod('useHealthConnectIfAvailable');
+    } else {
+      _deviceId = (await _deviceInfo.iosInfo).identifierForVendor;
     }
   }
 


### PR DESCRIPTION
Fixes #989.

According to the configure documentation:

> If useHealthConnectIfAvailable is true, Google Health Connect on Android will be used. Has no effect on iOS.

However, setting useHealthConnectIfAvailable to true on iOS triggers calls to an unimplemented method Channel API.

To address this issue, I confirmed that no method Channel API is invoked when useHealthConnectIfAvailable is set to true and configure is called on iOS, thereby ensuring that the issue no longer occurs.