### PR TITLE
[HEALTH]: Add default activity type when there is no match

### DIFF
--- a/packages/health/lib/src/health_value_types.dart
+++ b/packages/health/lib/src/health_value_types.dart
@@ -153,7 +153,9 @@ class WorkoutHealthValue extends HealthValue {
   factory WorkoutHealthValue.fromHealthDataPoint(dynamic dataPoint) =>
       WorkoutHealthValue(
           workoutActivityType: HealthWorkoutActivityType.values.firstWhere(
-              (element) => element.name == dataPoint['workoutActivityType']),
+            (element) => element.name == dataPoint['workoutActivityType'],
+            orElse: () => HealthWorkoutActivityType.OTHER,
+          ),
           totalEnergyBurned: dataPoint['totalEnergyBurned'] != null
               ? (dataPoint['totalEnergyBurned'] as num).toInt()
               : null,


### PR DESCRIPTION
### Changes: 
- set `HealthWorkoutActivityType.other` to the activity type when no match is found

### Reason: 
Currently there is no fallback when no `HealthWorkoutActivityType` matches the `dataPoint['workoutActivityType']` and package throws error.

### Issue:
Fixes #1015 