### PR TITLE
[health] Remove automatically added workout permissions

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -540,38 +540,6 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                     ),
                 )
             }
-            // Workout also needs distance and total energy burned too
-            if (typeKey == WORKOUT) {
-                if (access == 0) {
-                    permList.addAll(
-                        listOf(
-                            HealthPermission.getReadPermission(
-                                DistanceRecord::class
-                            ),
-                            HealthPermission.getReadPermission(
-                                TotalCaloriesBurnedRecord::class
-                            ),
-                        ),
-                    )
-                } else {
-                    permList.addAll(
-                        listOf(
-                            HealthPermission.getReadPermission(
-                                DistanceRecord::class
-                            ),
-                            HealthPermission.getReadPermission(
-                                TotalCaloriesBurnedRecord::class
-                            ),
-                            HealthPermission.getWritePermission(
-                                DistanceRecord::class
-                            ),
-                            HealthPermission.getWritePermission(
-                                TotalCaloriesBurnedRecord::class
-                            ),
-                        ),
-                    )
-                }
-            }
         }
         scope.launch {
             result.success(
@@ -624,38 +592,6 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                         ),
                     ),
                 )
-            }
-            // Workout also needs distance and total energy burned too
-            if (typeKey == WORKOUT) {
-                if (access == 0) {
-                    permList.addAll(
-                        listOf(
-                            HealthPermission.getReadPermission(
-                                DistanceRecord::class
-                            ),
-                            HealthPermission.getReadPermission(
-                                TotalCaloriesBurnedRecord::class
-                            ),
-                        ),
-                    )
-                } else {
-                    permList.addAll(
-                        listOf(
-                            HealthPermission.getReadPermission(
-                                DistanceRecord::class
-                            ),
-                            HealthPermission.getReadPermission(
-                                TotalCaloriesBurnedRecord::class
-                            ),
-                            HealthPermission.getWritePermission(
-                                DistanceRecord::class
-                            ),
-                            HealthPermission.getWritePermission(
-                                TotalCaloriesBurnedRecord::class
-                            ),
-                        ),
-                    )
-                }
             }
         }
         if (healthConnectRequestPermissionsLauncher == null) {


### PR DESCRIPTION
Workouts don't necessarily have distances or burnt calories. The health plugin automatically requests these permissions with no way to disable it.

Solution:
- Don't automatically request those permissions and make the package consumer declare the permissions manually

Keep in mind that this is a breaking change, since all users who previously relied on the permission from being added automatically now need to declare it themselves.
This PR only updates the code, but not the changelog or the documentation.