### PR TITLE
fix: add kotlin jvm target to build.gradle for gradle 8.0 update

### DIFF
--- a/packages/app_usage/android/build.gradle
+++ b/packages/app_usage/android/build.gradle
@@ -37,6 +37,10 @@ android {
         disable 'InvalidPackage'
     }
     namespace "dk.cachet.app_usage"
+    
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
https://docs.gradle.org/8.0/release-notes.html

> Starting with Gradle 8.0, precompiled script plugins use the configured [Java Toolchain](https://docs.gradle.org/8.0/userguide/toolchains.html) for the project or Java 8 if no toolchain is configured.