### PR TITLE
[Health] fixed hesPermissoins call for iOS

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -339,7 +339,7 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
             }
         }
         
-        result(false)
+        result(true)
     }
     
     func hasPermission(type: HKObjectType, access: Int) -> Bool? {


### PR DESCRIPTION
Fixed a bug in the iOS plugin. After access check, if all checks were correct - the call returned false instead of true