### PR TITLE
[Health] Updated device_info_plus version dependency

### DIFF
--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.1.2
+
+* Updated `device_info_plus` version dependency
+
 ## 11.1.1
 
 * Fix of [#1059](https://github.com/cph-cachet/flutter-plugins/issues/1059)

--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: '>=0.18.0 <0.20.0'
-  device_info_plus: '>=9.0.0 <11.0.0'
+  device_info_plus: '>=9.0.0 <12.0.0'
   json_annotation: ^4.8.0
   carp_serializable: ^2.0.0 # polymorphic json serialization
 


### PR DESCRIPTION
I have updated the version range to support the current version of device_info_plus.
There seem be no breaking changes that affect this plugin.