### PR TITLE
[Health] Fix NullPointerException when reading NUTRITION

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1516,7 +1516,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                         "sugar" to record.sugar?.inGrams,
                         "water" to null,
                         "zinc" to record.zinc?.inGrams,
-                        "name" to record.name!!,
+                        "name" to record.name,
                         "meal_type" to
                                 (mapTypeToMealType[
                                     record.mealType]


### PR DESCRIPTION
This PR is intended to fix issue described in #950
**NullPointerException when reading Nutrition from Health Connect**

More specifically, the issue described [in this comment](https://github.com/cph-cachet/flutter-plugins/issues/950#issuecomment-2561499336)

To fix the issue I simply remove non-null check

