### PR TITLE
Health 12/1092 update dependencies

### DIFF
--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Fix of [#1072](https://github.com/cph-cachet/flutter-plugins/issues/1072) and [#1074](https://github.com/cph-cachet/flutter-plugins/issues/1074)
 * Fix issue where iOS delete not deleting own records - PR [#1104](https://github.com/cph-cachet/flutter-plugins/pull/1104)
+* Updated `intl` to ^0.20.1 - Closes [#1092](https://github.com/cph-cachet/flutter-plugins/issues/1092)
+* Updated `device_info_plus` to ^11.2.0
+* Example app: Updated `permission_handler` to ^11.3.1
 
 ## 11.1.1
 

--- a/packages/health/example/pubspec.yaml
+++ b/packages/health/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  permission_handler: ^10.2.0
+  permission_handler: ^11.3.1
   carp_serializable: ^2.0.0 # polymorphic json serialization
   health:
     path: ../

--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: '>=0.18.0 <0.20.0'
-  device_info_plus: '>=9.0.0 <11.0.0'
+  intl: ^0.20.1
+  device_info_plus: ^11.2.0
   json_annotation: ^4.8.0
   carp_serializable: ^2.0.0 # polymorphic json serialization
 


### PR DESCRIPTION
* Updated `intl` to version ^0.20.1 to close issue #1092. (`packages/health/CHANGELOG.md`, `packages/health/pubspec.yaml`) [[1]](diffhunk://#diff-cc52b958696addd5f772d7cbdf7603787eabd15e1eb2f26b6be66cfe701f8fafR5-R7) [[2]](diffhunk://#diff-44549f2b52fc9b0ba120fa6b305fb9f1abdbbbf20f3b9b77b4713c6e192db31eL13-R14)
* Updated `device_info_plus` to version ^11.2.0. (`packages/health/CHANGELOG.md`, `packages/health/pubspec.yaml`) [[1]](diffhunk://#diff-cc52b958696addd5f772d7cbdf7603787eabd15e1eb2f26b6be66cfe701f8fafR5-R7) [[2]](diffhunk://#diff-44549f2b52fc9b0ba120fa6b305fb9f1abdbbbf20f3b9b77b4713c6e192db31eL13-R14)
* Updated `permission_handler` in the example app to version ^11.3.1. (`packages/health/CHANGELOG.md`, `packages/health/example/pubspec.yaml`) [[1]](diffhunk://#diff-cc52b958696addd5f772d7cbdf7603787eabd15e1eb2f26b6be66cfe701f8fafR5-R7) [[2]](diffhunk://#diff-3011bbc6702a9afd35b89344fe5538093c236ce878f321fbda73af8de9cc16f1L14-R14)