### PR TITLE
Health 12/950 nullpoint

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -1516,7 +1516,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                         "sugar" to record.sugar?.inGrams,
                         "water" to null,
                         "zinc" to record.zinc?.inGrams,
-                        "name" to record.name,
+                        "name" to (record.name ?: ""),
                         "meal_type" to
                                 (mapTypeToMealType[
                                     record.mealType]


### PR DESCRIPTION
[`packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt`](diffhunk://#diff-f5fe207c2ce82d1a008c7f2b540154d93f524a62468eda39e45399cb4e339132L1519-R1519): Modified the `name` field assignment to use a null-coalescing operator, `record.name` defaults to an empty string if it is null.