### PR TITLE
Health 12/1120 metadata

### DIFF
--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.2
+
+* iOS: Parse metadata to remove unsupported types - PR [#1120](https://github.com/cph-cachet/flutter-plugins/pull/1120)
+
 ## 12.0.1
 
 * Update of API and README doc
@@ -23,7 +27,6 @@
   <uses-permission android:name="android.permission.health.READ_LEAN_BODY_MASS"/>
   <uses-permission android:name="android.permission.health.WRITE_LEAN_BODY_MASS"/>
   ```
-
 * iOS: Add `WATER_TEMPERATURE` and `UNDERWATER_DEPTH` health values [#1096](https://github.com/cph-cachet/flutter-plugins/issues/1096)
 * iOS: Add support for `Underwater Diving` workout [#1096](https://github.com/cph-cachet/flutter-plugins/issues/1096)
 * Fix [#1072](https://github.com/cph-cachet/flutter-plugins/issues/1072) and [#1074](https://github.com/cph-cachet/flutter-plugins/issues/1074)


### PR DESCRIPTION
PR #1120 

### iOS metadata

* [`packages/health/ios/Classes/SwiftHealthPlugin.swift`](diffhunk://#diff-fcb95b3417850bbccd91ba91e0926efa717cd870b13db08066d8b697872973d4R1032-R1079): Adds `sanitizeMetadata` and `sanitizeArray` methods to clean metadata by removing unsupported types before processing.
* [`packages/health/ios/Classes/SwiftHealthPlugin.swift`](diffhunk://#diff-fcb95b3417850bbccd91ba91e0926efa717cd870b13db08066d8b697872973d4L863-R864): Updates metadata handling in multiple places to use the new `sanitizeMetadata` method instead of directly assigning metadata. [[1]](diffhunk://#diff-fcb95b3417850bbccd91ba91e0926efa717cd870b13db08066d8b697872973d4L863-R864) [[2]](diffhunk://#diff-fcb95b3417850bbccd91ba91e0926efa717cd870b13db08066d8b697872973d4L923-R915)