### PR TITLE
[Health] Add HC health history permission

### DIFF
--- a/packages/health/README.md
+++ b/packages/health/README.md
@@ -74,6 +74,16 @@ An example of asking for permission to read and write heart rate data is shown b
 <uses-permission android:name="android.permission.health.WRITE_HEART_RATE"/>
 ```
 
+By default, Health Connect restricts read data to 30 days from when permission has been granted.
+
+You can check and request access to historical data using the `isHealthDataHistoryAuthorized` and `requestHealthDataHistoryAuthorization` methods, respectively.
+
+The above methods require the following permission to be declared:
+
+```xml
+<uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
+```
+
 Accessing fitness data (e.g. Steps) requires permission to access the "Activity Recognition" API. To set it add the following line to your `AndroidManifest.xml` file.
 
 ```xml

--- a/packages/health/android/build.gradle
+++ b/packages/health/android/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation(composeBom)
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation("androidx.health.connect:connect-client:1.1.0-alpha07")
+    implementation("androidx.health.connect:connect-client:1.1.0-alpha11")
     def fragment_version = "1.6.2"
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
 

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.permission.HealthPermission.Companion.PERMISSION_READ_HEALTH_DATA_HISTORY
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_BREAKFAST
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_DINNER
@@ -147,6 +148,8 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         when (call.method) {
             "installHealthConnect" -> installHealthConnect(call, result)
             "getHealthConnectSdkStatus" -> getHealthConnectSdkStatus(call, result)
+            "isHealthDataHistoryAuthorized" -> isHealthDataHistoryAuthorized(call, result)
+            "requestHealthDataHistoryAuthorization" -> requestHealthDataHistoryAuthorization(call, result)
             "hasPermissions" -> hasPermissions(call, result)
             "requestAuthorization" -> requestAuthorization(call, result)
             "revokePermissions" -> revokePermissions(call, result)
@@ -510,6 +513,41 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             )
             return@filter !recordingMethodsToFilter.contains(record.metadata.recordingMethod)
         }
+    }
+
+    /**
+     * Checks if PERMISSION_READ_HEALTH_DATA_HISTORY has been granted
+     */
+    private fun isHealthDataHistoryAuthorized(call: MethodCall, result: Result) {
+        scope.launch {
+            result.success(
+                healthConnectClient
+                    .permissionController
+                    .getGrantedPermissions()
+                    .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_HISTORY)),
+            )
+        }
+    }
+
+    /**
+     * Requests authorization for PERMISSION_READ_HEALTH_DATA_HISTORY
+     */
+    private fun requestHealthDataHistoryAuthorization(call: MethodCall, result: Result) {
+        if (context == null) {
+            result.success(false)
+            return
+        }
+
+        if (healthConnectRequestPermissionsLauncher == null) {
+            result.success(false)
+            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+            return
+        }
+
+        // Store the result to be called in [onHealthConnectPermissionCallback]
+        mResult = result
+        isReplySubmitted = false
+        healthConnectRequestPermissionsLauncher!!.launch(setOf(PERMISSION_READ_HEALTH_DATA_HISTORY))
     }
 
     private fun hasPermissions(call: MethodCall, result: Result) {

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -9,7 +9,9 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.NonNull
+import androidx.health.connect.client.feature.ExperimentalFeatureAvailabilityApi
 import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.permission.HealthPermission.Companion.PERMISSION_READ_HEALTH_DATA_HISTORY
@@ -148,6 +150,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         when (call.method) {
             "installHealthConnect" -> installHealthConnect(call, result)
             "getHealthConnectSdkStatus" -> getHealthConnectSdkStatus(call, result)
+            "isHealthDataHistoryAvailable" -> isHealthDataHistoryAvailable(call, result)
             "isHealthDataHistoryAuthorized" -> isHealthDataHistoryAuthorized(call, result)
             "requestHealthDataHistoryAuthorization" -> requestHealthDataHistoryAuthorization(call, result)
             "hasPermissions" -> hasPermissions(call, result)
@@ -512,6 +515,20 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                 "Filtering record with recording method ${record.metadata.recordingMethod}, filtering by $recordingMethodsToFilter. Result: ${recordingMethodsToFilter.contains(record.metadata.recordingMethod)}"
             )
             return@filter !recordingMethodsToFilter.contains(record.metadata.recordingMethod)
+        }
+    }
+
+    /**
+     * Checks if the health data history feature is available on this device
+     */
+    @OptIn(ExperimentalFeatureAvailabilityApi::class)
+    private fun isHealthDataHistoryAvailable(call: MethodCall, result: Result) {
+        scope.launch {
+            result.success(
+                healthConnectClient
+                    .features
+                    .getFeatureStatus(HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_HISTORY) ==
+                    HealthConnectFeatures.FEATURE_STATUS_AVAILABLE)
         }
     }
 

--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -200,6 +200,48 @@ class Health {
     }
   }
 
+  /// Checks the current status of the Health Data History permission.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_HISTORY()
+  ///
+  ///
+  /// Android only. Returns true on iOS or false if an error occurs.
+  Future<bool> isHealthDataHistoryAuthorized() async {
+    if (Platform.isIOS) return true;
+
+    try {
+      final status =
+          await _channel.invokeMethod<bool>('isHealthDataHistoryAuthorized');
+      return status ?? false;
+    } catch (e) {
+      debugPrint('$runtimeType - Exception in getHealthConnectSdkStatus(): $e');
+      return false;
+    }
+  }
+
+  /// Requests the Health Data History permission.
+  ///
+  /// Returns true if successful, false otherwise.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_HISTORY()
+  ///
+  ///
+  /// Android only. Returns true on iOS or false if an error occurs.
+  Future<bool> requestHealthDataHistoryAuthorization() async {
+    if (Platform.isIOS) return true;
+
+    await _checkIfHealthConnectAvailableOnAndroid();
+    try {
+      final bool? isAuthorized =
+          await _channel.invokeMethod('requestHealthDataHistoryAuthorization');
+      return isAuthorized ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in requestHealthDataHistoryAuthorization(): $e');
+      return false;
+    }
+  }
+
   /// Requests permissions to access health data [types].
   ///
   /// Returns true if successful, false otherwise.

--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -200,7 +200,28 @@ class Health {
     }
   }
 
+  /// Checks if the Health Data History feature is available.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_HISTORY()
+  ///
+  ///
+  /// Android only. Returns false on iOS or if an error occurs.
+  Future<bool> isHealthDataHistoryAvailable() async {
+    if (Platform.isIOS) return false;
+
+    try {
+      final status =
+          await _channel.invokeMethod<bool>('isHealthDataHistoryAvailable');
+      return status ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in isHealthDataHistoryAvailable(): $e');
+      return false;
+    }
+  }
+
   /// Checks the current status of the Health Data History permission.
+  /// Make sure to check [isHealthConnectAvailable] before calling this method.
   ///
   /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_HISTORY()
   ///

--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -235,7 +235,8 @@ class Health {
           await _channel.invokeMethod<bool>('isHealthDataHistoryAuthorized');
       return status ?? false;
     } catch (e) {
-      debugPrint('$runtimeType - Exception in getHealthConnectSdkStatus(): $e');
+      debugPrint(
+          '$runtimeType - Exception in isHealthDataHistoryAuthorized(): $e');
       return false;
     }
   }


### PR DESCRIPTION
Created two new methods isHealthDataHistoryAuthorized() and requestHealthDataHistoryAuthorization().

Both methods are no-op on iOS and return true since Apple Health does not restrict history length.

Closes #1126