### PR TITLE
[HEALTH] - move CARDIO_DANCE to both, as it is available for Android and ios

### DIFF
--- a/packages/health/lib/src/heath_data_types.dart
+++ b/packages/health/lib/src/heath_data_types.dart
@@ -466,6 +466,7 @@ enum HealthWorkoutActivityType {
   BASKETBALL,
   BIKING, // This also entails the iOS version where it is called CYCLING
   BOXING,
+  CARDIO_DANCE,
   CRICKET,
   CROSS_COUNTRY_SKIING,
   CURLING,
@@ -504,7 +505,6 @@ enum HealthWorkoutActivityType {
   // iOS only
   BARRE,
   BOWLING,
-  CARDIO_DANCE,
   CLIMBING,
   COOLDOWN,
   CORE_TRAINING,


### PR DESCRIPTION
HealthWorkoutActivityType.CARDIO_DANCE is available on ios and andriod. In heath_data_types.dart it is listed under `// iOS only`