### PR TITLE
Add deviceModel for iOS health data identification

### DIFF
--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.2.0
+
+* iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
+
 ## 12.1.0
 
 * Add delete record by UUID method. See function `deleteByUUID(required String uuid, HealthDataType? type)`

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -902,6 +902,7 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.device?.model ?? "unknown",
                         "recording_method": (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? RecordingMethod.manual.rawValue
                             : RecordingMethod.automatic.rawValue,

--- a/packages/health/ios/health.podspec
+++ b/packages/health/ios/health.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'health'
-  s.version          = '12.1.0'
+  s.version          = '12.2.0'
   s.summary          = 'Wrapper for Apple\'s HealthKit on iOS and Google\'s Health Connect on Android.'
   s.description      = <<-DESC
 Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.

--- a/packages/health/lib/health.g.dart
+++ b/packages/health/lib/health.g.dart
@@ -27,6 +27,7 @@ HealthDataPoint _$HealthDataPointFromJson(Map<String, dynamic> json) =>
           : WorkoutSummary.fromJson(
               json['workoutSummary'] as Map<String, dynamic>),
       metadata: json['metadata'] as Map<String, dynamic>?,
+      deviceModel: json['deviceModel'] as String?,
     );
 
 Map<String, dynamic> _$HealthDataPointToJson(HealthDataPoint instance) =>
@@ -45,6 +46,7 @@ Map<String, dynamic> _$HealthDataPointToJson(HealthDataPoint instance) =>
       if (instance.workoutSummary?.toJson() case final value?)
         'workoutSummary': value,
       if (instance.metadata case final value?) 'metadata': value,
+      if (instance.deviceModel case final value?) 'deviceModel': value,
     };
 
 const _$HealthDataTypeEnumMap = {

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -55,6 +55,11 @@ class HealthDataPoint {
   /// The metadata for this data point.
   Map<String, dynamic>? metadata;
 
+  /// The source of the data, whether from the iPhone or Watch or something else.
+  /// Only available fo iOS
+  /// On Android: always return null
+  String? deviceModel;
+
   HealthDataPoint({
     required this.uuid,
     required this.value,
@@ -69,6 +74,7 @@ class HealthDataPoint {
     this.recordingMethod = RecordingMethod.unknown,
     this.workoutSummary,
     this.metadata,
+    this.deviceModel,
   }) {
     // set the value to minutes rather than the category
     // returned by the native API
@@ -137,6 +143,7 @@ class HealthDataPoint {
         : Map<String, dynamic>.from(dataPoint['metadata'] as Map);
     final unit = dataTypeToUnit[dataType] ?? HealthDataUnit.UNKNOWN_UNIT;
     final String? uuid = dataPoint["uuid"] as String?;
+    final String? deviceModel = dataPoint["device_model"] as String?;
 
     // Set WorkoutSummary, if available.
     WorkoutSummary? workoutSummary;
@@ -163,6 +170,7 @@ class HealthDataPoint {
       recordingMethod: RecordingMethod.fromInt(recordingMethod),
       workoutSummary: workoutSummary,
       metadata: metadata,
+      deviceModel: deviceModel,
     );
   }
 
@@ -180,7 +188,8 @@ class HealthDataPoint {
     sourceName: $sourceName
     recordingMethod: $recordingMethod
     workoutSummary: $workoutSummary
-    metadata: $metadata""";
+    metadata: $metadata
+    deviceModel: $deviceModel""";
 
   @override
   bool operator ==(Object other) =>
@@ -196,9 +205,10 @@ class HealthDataPoint {
       sourceId == other.sourceId &&
       sourceName == other.sourceName &&
       recordingMethod == other.recordingMethod &&
-      metadata == other.metadata;
+      metadata == other.metadata &&
+      deviceModel == other.deviceModel;
 
   @override
   int get hashCode => Object.hash(uuid, value, unit, dateFrom, dateTo, type,
-      sourcePlatform, sourceDeviceId, sourceId, sourceName, metadata);
+      sourcePlatform, sourceDeviceId, sourceId, sourceName, metadata, deviceModel);
 }

--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health
 description: Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.
-version: 12.1.0
+version: 12.2.0
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/health
 
 environment:


### PR DESCRIPTION
Introduce a new `deviceModel` field to identify the source of health data on iOS devices, including iPhone and Watch. Update the version to 12.2.0.