### PR TITLE
Add background health data permissions for Android

### DIFF
--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 12.2.0
 
 * iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
+* Android: Add read health data in background - PR [#1184](https://github.com/cph-cachet/flutter-plugins/pull/1184)
 
 ## 12.1.0
 

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -15,6 +15,7 @@ import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.permission.HealthPermission.Companion.PERMISSION_READ_HEALTH_DATA_HISTORY
+import androidx.health.connect.client.permission.HealthPermission.Companion.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_BREAKFAST
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_DINNER
@@ -153,6 +154,9 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             "isHealthDataHistoryAvailable" -> isHealthDataHistoryAvailable(call, result)
             "isHealthDataHistoryAuthorized" -> isHealthDataHistoryAuthorized(call, result)
             "requestHealthDataHistoryAuthorization" -> requestHealthDataHistoryAuthorization(call, result)
+            "isHealthDataInBackgroundAvailable" -> isHealthDataInBackgroundAvailable(call, result)
+            "isHealthDataInBackgroundAuthorized" -> isHealthDataInBackgroundAuthorized(call, result)
+            "requestHealthDataInBackgroundAuthorization" -> requestHealthDataInBackgroundAuthorization(call, result)
             "hasPermissions" -> hasPermissions(call, result)
             "requestAuthorization" -> requestAuthorization(call, result)
             "revokePermissions" -> revokePermissions(call, result)
@@ -566,6 +570,55 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         mResult = result
         isReplySubmitted = false
         healthConnectRequestPermissionsLauncher!!.launch(setOf(PERMISSION_READ_HEALTH_DATA_HISTORY))
+    }
+
+    /**
+     * Checks if the health data in background feature is available on this device
+     */
+    @OptIn(ExperimentalFeatureAvailabilityApi::class)
+    private fun isHealthDataInBackgroundAvailable(call: MethodCall, result: Result) {
+        scope.launch {
+            result.success(
+                healthConnectClient
+                    .features
+                    .getFeatureStatus(HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND) ==
+                    HealthConnectFeatures.FEATURE_STATUS_AVAILABLE)
+        }
+    }
+
+    /**
+     * Checks if PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND has been granted
+     */
+    private fun isHealthDataInBackgroundAuthorized(call: MethodCall, result: Result) {
+        scope.launch {
+            result.success(
+                healthConnectClient
+                    .permissionController
+                    .getGrantedPermissions()
+                    .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)),
+            )
+        }
+    }
+
+    /**
+     * Requests authorization for PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND
+     */
+    private fun requestHealthDataInBackgroundAuthorization(call: MethodCall, result: Result) {
+        if (context == null) {
+            result.success(false)
+            return
+        }
+
+        if (healthConnectRequestPermissionsLauncher == null) {
+            result.success(false)
+            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+            return
+        }
+
+        // Store the result to be called in [onHealthConnectPermissionCallback]
+        mResult = result
+        isReplySubmitted = false
+        healthConnectRequestPermissionsLauncher!!.launch(setOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND))
     }
 
     private fun hasPermissions(call: MethodCall, result: Result) {

--- a/packages/health/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/health/example/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,9 @@
     <!-- For reading historical data - more than 30 days ago since permission given -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
 
+    <!-- For reading data in background -->
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"/>
+
     <application
         android:label="health_example"
         android:name="${applicationName}"

--- a/packages/health/example/lib/main.dart
+++ b/packages/health/example/lib/main.dart
@@ -126,6 +126,9 @@ class HealthAppState extends State<HealthApp> {
         // request access to read historic data
         await health.requestHealthDataHistoryAuthorization();
 
+        // request access in background
+        await health.requestHealthDataInBackgroundAuthorization();
+
       } catch (error) {
         debugPrint("Exception in authorize: $error");
       }

--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -264,6 +264,70 @@ class Health {
     }
   }
 
+  /// Checks if the Health Data in Background feature is available.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND()
+  ///
+  ///
+  /// Android only. Returns false on iOS or if an error occurs.
+  Future<bool> isHealthDataInBackgroundAvailable() async {
+    if (Platform.isIOS) return false;
+
+    try {
+      final status =
+          await _channel.invokeMethod<bool>('isHealthDataInBackgroundAvailable');
+      return status ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in isHealthDataInBackgroundAvailable(): $e');
+      return false;
+    }
+  }
+
+  /// Checks the current status of the Health Data in Background permission.
+  /// Make sure to check [isHealthConnectAvailable] before calling this method.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND()
+  ///
+  ///
+  /// Android only. Returns true on iOS or false if an error occurs.
+  Future<bool> isHealthDataInBackgroundAuthorized() async {
+    if (Platform.isIOS) return true;
+
+    try {
+      final status =
+          await _channel.invokeMethod<bool>('isHealthDataInBackgroundAuthorized');
+      return status ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in isHealthDataInBackgroundAuthorized(): $e');
+      return false;
+    }
+  }
+
+  /// Requests the Health Data in Background permission.
+  ///
+  /// Returns true if successful, false otherwise.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND()
+  ///
+  ///
+  /// Android only. Returns true on iOS or false if an error occurs.
+  Future<bool> requestHealthDataInBackgroundAuthorization() async {
+    if (Platform.isIOS) return true;
+
+    await _checkIfHealthConnectAvailableOnAndroid();
+    try {
+      final bool? isAuthorized =
+          await _channel.invokeMethod('requestHealthDataInBackgroundAuthorization');
+      return isAuthorized ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in requestHealthDataInBackgroundAuthorization(): $e');
+      return false;
+    }
+  }
+
   /// Requests permissions to access health data [types].
   ///
   /// Returns true if successful, false otherwise.


### PR DESCRIPTION
Implement background health data permission handling for Android, allowing access to health data in the background.