### PR TITLE
Health 12.2.0

### DIFF
--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.2.0
+
+* iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
+
 ## 12.1.0
 
 * Add delete record by UUID method. See function `deleteByUUID(required String uuid, HealthDataType? type)`

--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 12.2.0
 
 * iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
+* Android: Add read health data in background - PR [#1184](https://github.com/cph-cachet/flutter-plugins/pull/1184)
 
 ## 12.1.0
 

--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -3,6 +3,7 @@
 * iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
 * Android: Add read health data in background - PR [#1184](https://github.com/cph-cachet/flutter-plugins/pull/1184)
 * Fix [#1169](https://github.com/cph-cachet/flutter-plugins/issues/1169) where `meal_type` property in `Nutrition` was null always
+* iOS: Add `CARDIO_DANCE` HealthDataType - [#1146](https://github.com/cph-cachet/flutter-plugins/pull/1146)
 
 ## 12.1.0
 

--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
 * Android: Add read health data in background - PR [#1184](https://github.com/cph-cachet/flutter-plugins/pull/1184)
+* Fix [#1169](https://github.com/cph-cachet/flutter-plugins/issues/1169) where `meal_type` property in `Nutrition` was null always
 
 ## 12.1.0
 

--- a/packages/health/README.md
+++ b/packages/health/README.md
@@ -311,6 +311,17 @@ List<HealthDataPoint> points = ...;
 points = health.removeDuplicates(points);
 ```
 
+### Android: Reading Health Data in Background
+Currently health connect allows apps to read health data in the background. In order to achieve this add the following permission to your `AndroidManifest.XML`:
+```XML
+<!-- For reading data in background -->
+<uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"/>
+```
+Furthermore, the plugin now exposes three new functions to help you check and request access to read data in the background:
+1. `isHealthDataInBackgroundAvailable()`: Checks if the Health Data in Background feature is available
+2. `isHealthDataInBackgroundAuthorized()`: Checks the current status of the Health Data in Background permission
+3. `requestHealthDataInBackgroundAuthorization()`: Requests the Health Data in Background permission.
+
 ## Data Types
 
 The plugin supports the following [`HealthDataType`](https://pub.dev/documentation/health/latest/health/HealthDataType.html).

--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -15,6 +15,7 @@ import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.permission.HealthPermission.Companion.PERMISSION_READ_HEALTH_DATA_HISTORY
+import androidx.health.connect.client.permission.HealthPermission.Companion.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_BREAKFAST
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_DINNER
@@ -153,6 +154,9 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             "isHealthDataHistoryAvailable" -> isHealthDataHistoryAvailable(call, result)
             "isHealthDataHistoryAuthorized" -> isHealthDataHistoryAuthorized(call, result)
             "requestHealthDataHistoryAuthorization" -> requestHealthDataHistoryAuthorization(call, result)
+            "isHealthDataInBackgroundAvailable" -> isHealthDataInBackgroundAvailable(call, result)
+            "isHealthDataInBackgroundAuthorized" -> isHealthDataInBackgroundAuthorized(call, result)
+            "requestHealthDataInBackgroundAuthorization" -> requestHealthDataInBackgroundAuthorization(call, result)
             "hasPermissions" -> hasPermissions(call, result)
             "requestAuthorization" -> requestAuthorization(call, result)
             "revokePermissions" -> revokePermissions(call, result)
@@ -566,6 +570,55 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         mResult = result
         isReplySubmitted = false
         healthConnectRequestPermissionsLauncher!!.launch(setOf(PERMISSION_READ_HEALTH_DATA_HISTORY))
+    }
+
+    /**
+     * Checks if the health data in background feature is available on this device
+     */
+    @OptIn(ExperimentalFeatureAvailabilityApi::class)
+    private fun isHealthDataInBackgroundAvailable(call: MethodCall, result: Result) {
+        scope.launch {
+            result.success(
+                healthConnectClient
+                    .features
+                    .getFeatureStatus(HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND) ==
+                    HealthConnectFeatures.FEATURE_STATUS_AVAILABLE)
+        }
+    }
+
+    /**
+     * Checks if PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND has been granted
+     */
+    private fun isHealthDataInBackgroundAuthorized(call: MethodCall, result: Result) {
+        scope.launch {
+            result.success(
+                healthConnectClient
+                    .permissionController
+                    .getGrantedPermissions()
+                    .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)),
+            )
+        }
+    }
+
+    /**
+     * Requests authorization for PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND
+     */
+    private fun requestHealthDataInBackgroundAuthorization(call: MethodCall, result: Result) {
+        if (context == null) {
+            result.success(false)
+            return
+        }
+
+        if (healthConnectRequestPermissionsLauncher == null) {
+            result.success(false)
+            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+            return
+        }
+
+        // Store the result to be called in [onHealthConnectPermissionCallback]
+        mResult = result
+        isReplySubmitted = false
+        healthConnectRequestPermissionsLauncher!!.launch(setOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND))
     }
 
     private fun hasPermissions(call: MethodCall, result: Result) {

--- a/packages/health/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/health/example/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,9 @@
     <!-- For reading historical data - more than 30 days ago since permission given -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
 
+    <!-- For reading data in background -->
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"/>
+
     <application
         android:label="health_example"
         android:name="${applicationName}"

--- a/packages/health/example/lib/main.dart
+++ b/packages/health/example/lib/main.dart
@@ -197,6 +197,27 @@ class HealthAppState extends State<HealthApp> {
     });
   }
 
+  Future<void> writeNutritionDataTest() async {
+    final now = DateTime.now();
+    final earlier = now.subtract(const Duration(minutes: 20));
+
+    // Add nutrition data
+    bool success = await health.writeMeal(
+      mealType: MealType.DINNER,
+      startTime: earlier,
+      endTime: now,
+      caloriesConsumed: 1000,
+      carbohydrates: 50,
+      protein: 25,
+      fatTotal: 50,
+      name: "Banana",
+    );
+
+    setState(() {
+      _state = success ? AppState.DATA_ADDED : AppState.DATA_NOT_ADDED;
+    });
+  }
+
   /// Add some random health data.
   /// Note that you should ensure that you have permissions to add the
   /// following data types.
@@ -740,7 +761,7 @@ class HealthAppState extends State<HealthApp> {
         if (p.value is NutritionHealthValue) {
           return ListTile(
             title: Text(
-                "${p.typeString} ${(p.value as NutritionHealthValue).mealType}: ${(p.value as NutritionHealthValue).name}"),
+                "${p.typeString} ${(p.value as NutritionHealthValue).meal_type}: ${(p.value as NutritionHealthValue).name}"),
             trailing:
                 Text('${(p.value as NutritionHealthValue).calories} kcal'),
             subtitle: Text('${p.dateFrom} - ${p.dateTo}\n${p.recordingMethod}'),

--- a/packages/health/example/lib/main.dart
+++ b/packages/health/example/lib/main.dart
@@ -197,27 +197,6 @@ class HealthAppState extends State<HealthApp> {
     });
   }
 
-  Future<void> writeNutritionDataTest() async {
-    final now = DateTime.now();
-    final earlier = now.subtract(const Duration(minutes: 20));
-
-    // Add nutrition data
-    bool success = await health.writeMeal(
-      mealType: MealType.DINNER,
-      startTime: earlier,
-      endTime: now,
-      caloriesConsumed: 1000,
-      carbohydrates: 50,
-      protein: 25,
-      fatTotal: 50,
-      name: "Banana",
-    );
-
-    setState(() {
-      _state = success ? AppState.DATA_ADDED : AppState.DATA_NOT_ADDED;
-    });
-  }
-
   /// Add some random health data.
   /// Note that you should ensure that you have permissions to add the
   /// following data types.

--- a/packages/health/example/lib/main.dart
+++ b/packages/health/example/lib/main.dart
@@ -126,6 +126,9 @@ class HealthAppState extends State<HealthApp> {
         // request access to read historic data
         await health.requestHealthDataHistoryAuthorization();
 
+        // request access in background
+        await health.requestHealthDataInBackgroundAuthorization();
+
       } catch (error) {
         debugPrint("Exception in authorize: $error");
       }

--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -902,6 +902,7 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.device?.model ?? "unknown",
                         "recording_method": (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? RecordingMethod.manual.rawValue
                             : RecordingMethod.automatic.rawValue,

--- a/packages/health/ios/health.podspec
+++ b/packages/health/ios/health.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'health'
-  s.version          = '12.1.0'
+  s.version          = '12.2.0'
   s.summary          = 'Wrapper for Apple\'s HealthKit on iOS and Google\'s Health Connect on Android.'
   s.description      = <<-DESC
 Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.

--- a/packages/health/lib/health.g.dart
+++ b/packages/health/lib/health.g.dart
@@ -479,7 +479,7 @@ NutritionHealthValue _$NutritionHealthValueFromJson(
         Map<String, dynamic> json) =>
     NutritionHealthValue(
       name: json['name'] as String?,
-      mealType: json['mealType'] as String?,
+      meal_type: json['meal_type'] as String?,
       calories: (json['calories'] as num?)?.toDouble(),
       protein: (json['protein'] as num?)?.toDouble(),
       fat: (json['fat'] as num?)?.toDouble(),
@@ -529,7 +529,7 @@ Map<String, dynamic> _$NutritionHealthValueToJson(
     <String, dynamic>{
       if (instance.$type case final value?) '__type': value,
       if (instance.name case final value?) 'name': value,
-      if (instance.mealType case final value?) 'mealType': value,
+      if (instance.meal_type case final value?) 'meal_type': value,
       if (instance.calories case final value?) 'calories': value,
       if (instance.protein case final value?) 'protein': value,
       if (instance.fat case final value?) 'fat': value,

--- a/packages/health/lib/health.g.dart
+++ b/packages/health/lib/health.g.dart
@@ -27,6 +27,7 @@ HealthDataPoint _$HealthDataPointFromJson(Map<String, dynamic> json) =>
           : WorkoutSummary.fromJson(
               json['workoutSummary'] as Map<String, dynamic>),
       metadata: json['metadata'] as Map<String, dynamic>?,
+      deviceModel: json['deviceModel'] as String?,
     );
 
 Map<String, dynamic> _$HealthDataPointToJson(HealthDataPoint instance) =>
@@ -45,6 +46,7 @@ Map<String, dynamic> _$HealthDataPointToJson(HealthDataPoint instance) =>
       if (instance.workoutSummary?.toJson() case final value?)
         'workoutSummary': value,
       if (instance.metadata case final value?) 'metadata': value,
+      if (instance.deviceModel case final value?) 'deviceModel': value,
     };
 
 const _$HealthDataTypeEnumMap = {

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -55,6 +55,11 @@ class HealthDataPoint {
   /// The metadata for this data point.
   Map<String, dynamic>? metadata;
 
+  /// The source of the data, whether from the iPhone or Watch or something else.
+  /// Only available fo iOS
+  /// On Android: always return null
+  String? deviceModel;
+
   HealthDataPoint({
     required this.uuid,
     required this.value,
@@ -69,6 +74,7 @@ class HealthDataPoint {
     this.recordingMethod = RecordingMethod.unknown,
     this.workoutSummary,
     this.metadata,
+    this.deviceModel,
   }) {
     // set the value to minutes rather than the category
     // returned by the native API
@@ -137,6 +143,7 @@ class HealthDataPoint {
         : Map<String, dynamic>.from(dataPoint['metadata'] as Map);
     final unit = dataTypeToUnit[dataType] ?? HealthDataUnit.UNKNOWN_UNIT;
     final String? uuid = dataPoint["uuid"] as String?;
+    final String? deviceModel = dataPoint["device_model"] as String?;
 
     // Set WorkoutSummary, if available.
     WorkoutSummary? workoutSummary;
@@ -163,6 +170,7 @@ class HealthDataPoint {
       recordingMethod: RecordingMethod.fromInt(recordingMethod),
       workoutSummary: workoutSummary,
       metadata: metadata,
+      deviceModel: deviceModel,
     );
   }
 
@@ -180,7 +188,8 @@ class HealthDataPoint {
     sourceName: $sourceName
     recordingMethod: $recordingMethod
     workoutSummary: $workoutSummary
-    metadata: $metadata""";
+    metadata: $metadata
+    deviceModel: $deviceModel""";
 
   @override
   bool operator ==(Object other) =>
@@ -196,9 +205,10 @@ class HealthDataPoint {
       sourceId == other.sourceId &&
       sourceName == other.sourceName &&
       recordingMethod == other.recordingMethod &&
-      metadata == other.metadata;
+      metadata == other.metadata &&
+      deviceModel == other.deviceModel;
 
   @override
   int get hashCode => Object.hash(uuid, value, unit, dateFrom, dateTo, type,
-      sourcePlatform, sourceDeviceId, sourceId, sourceName, metadata);
+      sourcePlatform, sourceDeviceId, sourceId, sourceName, metadata, deviceModel);
 }

--- a/packages/health/lib/src/health_plugin.dart
+++ b/packages/health/lib/src/health_plugin.dart
@@ -264,6 +264,70 @@ class Health {
     }
   }
 
+  /// Checks if the Health Data in Background feature is available.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND()
+  ///
+  ///
+  /// Android only. Returns false on iOS or if an error occurs.
+  Future<bool> isHealthDataInBackgroundAvailable() async {
+    if (Platform.isIOS) return false;
+
+    try {
+      final status =
+          await _channel.invokeMethod<bool>('isHealthDataInBackgroundAvailable');
+      return status ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in isHealthDataInBackgroundAvailable(): $e');
+      return false;
+    }
+  }
+
+  /// Checks the current status of the Health Data in Background permission.
+  /// Make sure to check [isHealthConnectAvailable] before calling this method.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND()
+  ///
+  ///
+  /// Android only. Returns true on iOS or false if an error occurs.
+  Future<bool> isHealthDataInBackgroundAuthorized() async {
+    if (Platform.isIOS) return true;
+
+    try {
+      final status =
+          await _channel.invokeMethod<bool>('isHealthDataInBackgroundAuthorized');
+      return status ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in isHealthDataInBackgroundAuthorized(): $e');
+      return false;
+    }
+  }
+
+  /// Requests the Health Data in Background permission.
+  ///
+  /// Returns true if successful, false otherwise.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/permission/HealthPermission#PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND()
+  ///
+  ///
+  /// Android only. Returns true on iOS or false if an error occurs.
+  Future<bool> requestHealthDataInBackgroundAuthorization() async {
+    if (Platform.isIOS) return true;
+
+    await _checkIfHealthConnectAvailableOnAndroid();
+    try {
+      final bool? isAuthorized =
+          await _channel.invokeMethod('requestHealthDataInBackgroundAuthorization');
+      return isAuthorized ?? false;
+    } catch (e) {
+      debugPrint(
+          '$runtimeType - Exception in requestHealthDataInBackgroundAuthorization(): $e');
+      return false;
+    }
+  }
+
   /// Requests permissions to access health data [types].
   ///
   /// Returns true if successful, false otherwise.

--- a/packages/health/lib/src/health_value_types.dart
+++ b/packages/health/lib/src/health_value_types.dart
@@ -426,7 +426,7 @@ class NutritionHealthValue extends HealthValue {
   String? name;
 
   /// The type of meal.
-  String? mealType;
+  String? meal_type;
 
   /// The amount of calories in kcal.
   double? calories;
@@ -556,7 +556,7 @@ class NutritionHealthValue extends HealthValue {
 
   NutritionHealthValue({
     this.name,
-    this.mealType,
+    this.meal_type,
     this.calories,
     this.protein,
     this.fat,
@@ -625,7 +625,7 @@ class NutritionHealthValue extends HealthValue {
     name: ${name.toString()},
     carbs: ${carbs.toString()},
     caffeine: ${caffeine.toString()},
-    mealType: $mealType,
+    mealType: $meal_type,
     vitaminA: ${vitaminA.toString()},
     b1Thiamine: ${b1Thiamine.toString()},
     b2Riboflavin: ${b2Riboflavin.toString()},
@@ -668,7 +668,7 @@ class NutritionHealthValue extends HealthValue {
   bool operator ==(Object other) =>
       other is NutritionHealthValue &&
       other.name == name &&
-      other.mealType == mealType &&
+      other.meal_type == meal_type &&
       other.calories == calories &&
       other.protein == protein &&
       other.fat == fat &&

--- a/packages/health/lib/src/heath_data_types.dart
+++ b/packages/health/lib/src/heath_data_types.dart
@@ -470,6 +470,7 @@ enum HealthWorkoutActivityType {
   BASKETBALL,
   BIKING, // This also entails the iOS version where it is called CYCLING
   BOXING,
+  CARDIO_DANCE,
   CRICKET,
   CROSS_COUNTRY_SKIING,
   CURLING,
@@ -508,7 +509,6 @@ enum HealthWorkoutActivityType {
   // iOS only
   BARRE,
   BOWLING,
-  CARDIO_DANCE,
   CLIMBING,
   COOLDOWN,
   CORE_TRAINING,

--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health
 description: Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.
-version: 12.1.0
+version: 12.2.0
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/health
 
 environment:


### PR DESCRIPTION
## 12.2.0

* iOS: Add `CARDIO_DANCE` HealthDataType - [#1146](https://github.com/cph-cachet/flutter-plugins/pull/1146)
* iOS: Add `deviceModel` in returned Health data to identify the device that generated the data of the receiver. (in iOS `source_name` represents the revision of the source responsible for saving the receiver.)
* Android: Add read health data in background - PR [#1184](https://github.com/cph-cachet/flutter-plugins/pull/1184)
* Fix [#1169](https://github.com/cph-cachet/flutter-plugins/issues/1169) where `meal_type` property in `Nutrition` was null always