### PR TITLE
(chore): Add Swift version to health plugin podspec

### DIFF
--- a/packages/health/ios/health.podspec
+++ b/packages/health/ios/health.podspec
@@ -18,5 +18,6 @@ Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.
 
   s.ios.deployment_target = '14.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.swift_version = '5.0'
 end
 


### PR DESCRIPTION
# What's new
Added the Swift version to the Pod spec for the health plugin. In [add-to-app](https://docs.flutter.dev/add-to-app) implementations in Flutter, the Swift version can't be inherited from the project (since it is regenerated on every clean run).

As such, building a project from scratch (e.g., on a CI pipeline) would throw an error expecting the Swift version to be present.