### PR TITLE
Fix Mindfulness cannot save

### DIFF
--- a/packages/health/ios/Classes/HealthDataWriter.swift
+++ b/packages/health/ios/Classes/HealthDataWriter.swift
@@ -45,10 +45,17 @@ class HealthDataWriter {
         ]
         
         let sample: HKObject
-        
+        let sampleValue: Int
+
+        if type == "MINDFULNESS" {
+            sampleValue = HKCategoryValue.notApplicable.rawValue
+        } else {
+            sampleValue = Int(value)
+        }
+
         if dataTypesDict[type]!.isKind(of: HKCategoryType.self) {
             sample = HKCategorySample(
-                type: dataTypesDict[type] as! HKCategoryType, value: Int(value), start: dateFrom,
+                type: dataTypesDict[type] as! HKCategoryType, value: sampleValue, start: dateFrom,
                 end: dateTo, metadata: metadata)
         } else {
             let quantity = HKQuantity(unit: unitDict[unit]!, doubleValue: value)


### PR DESCRIPTION
For mindful data, writing health data will throw an exception:
Thread 1: "Value 2 is not compatible with type HKCategoryTypeIdentifierMindfulSession"

Example:
```
final health = Health();

await health.configure();

var types = [HealthDataType.MINDFULNESS];

bool requested = await health.requestAuthorization(types, permissions:[HealthDataAccess.WRITE]);

if (!requested) return;

bool success = await health.writeHealthData(
  value: totalTime,
  unit: HealthDataUnit.MINUTE,
  type: HealthDataType.MINDFULNESS,
  startTime: startTime,
  endTime: endTime);
```

And solution:
https://stackoverflow.com/questions/58200979/how-to-write-mindful-minutes-to-healthkit