### PR TITLE
[Android] - Flag `TotalCaloriesBurnedRecord` permission as optional

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -404,18 +404,28 @@ class HealthDataReader(
             }
 
             // Get energy burned data
-            val energyBurnedRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = TotalCaloriesBurnedRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
-                    ),
-                ),
-            )
             var totalEnergyBurned = 0.0
-            for (energyBurnedRec in energyBurnedRequest.records) {
-                totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+            try {
+                val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+                val energyPermission = HealthPermission.getReadPermission(TotalCaloriesBurnedRecord::class)
+                if (grantedPermissions.contains(energyPermission)) {
+                    val energyBurnedRequest = healthConnectClient.readRecords(
+                        ReadRecordsRequest(
+                            recordType = TotalCaloriesBurnedRecord::class,
+                            timeRangeFilter = TimeRangeFilter.between(
+                                record.startTime,
+                                record.endTime,
+                            ),
+                        ),
+                    )
+                    for (energyBurnedRec in energyBurnedRequest.records) {
+                        totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+                    }
+                } else {
+                    Log.i("FLUTTER_HEALTH", "TotalCaloriesBurned permission not granted; skipping energy aggregation")
+                }
+            } catch (e: Exception) {
+                Log.w("FLUTTER_HEALTH", "Skipping TotalCaloriesBurned: ${e.message}")
             }
 
             // Get steps data


### PR DESCRIPTION
### Issue
In the current implementation of `HealthDataReader.handleWorkoutData()` is forcing us to have `TotalCaloriesBurned` permissions in our `AndroidManifest.xml`:
```
... [other permissions]
<uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED"/>
<uses-permission android:name="android.permission.health.WRITE_TOTAL_CALORIES_BURNED"/>
```
which can lead to Google review rejection if we don't actually has a feature to utilise TotalCaloriesBurned `(Excessive data access for declared feature)`. If we don't have those permissions added, we will get this error:
```
I/FLUTTER_HEALTH::ERROR(11781): Unable to return WORKOUT due to the following exception:
E/FLUTTER_HEALTH::ERROR(11781): java.lang.SecurityException: android.health.connect.HealthConnectException: java.lang.SecurityException: Caller doesn't have android.permission.health.READ_TOTAL_CALORIES_BURNED to read to record typeclass android.health.connect.datatypes.TotalCaloriesBurnedRecord
```

### Reason

**Why is this necessary:**

Because some apps out there might not require to utilise this data.

### Solution
Some apps out there might not utilise this data. So in order to solve this issue, we would need to make `READ/WRITE_TOTAL_CALORIES_BURNED` as optional in `AndroidManifest.xml`. This PR adds a condition to check if the permission is present and granted, otherwise will skip to calculate `totalEnergyBurned`.

> Note: Once you merged this PR, ensure you don't have `HealthDataType.TOTAL_CALORIES_BURNED` or remove if it's present on your Flutter side implementation.