### PR TITLE
movesense_plus v. 1.2.0 published

### DIFF
--- a/packages/movesense_plus/CHANGELOG.md
+++ b/packages/movesense_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+* connect and disconnect method not async
+* update to docs
+
 ## 1.1.1
 
 Update of docs to highlight that the `address` format is platform dependent:

--- a/packages/movesense_plus/example/lib/main.dart
+++ b/packages/movesense_plus/example/lib/main.dart
@@ -84,10 +84,10 @@ class MovesenseHomePageState extends State<MovesenseHomePage> {
   void onButtonPressed() {
     setState(() {
       if (!device.isConnected) {
-        // if not connected, connect to the device
+        // if not connected, start connecting to the device
         device.connect();
       } else {
-        // when connected, first get device info and battery status
+        // if connected, first get device info and battery status
         device.getDeviceInfo().then(
           (info) => debugPrint('>> Product name: ${info?.productName}'),
         );

--- a/packages/movesense_plus/lib/movesense_device.dart
+++ b/packages/movesense_plus/lib/movesense_device.dart
@@ -63,13 +63,14 @@ class MovesenseDevice {
   /// See https://www.movesense.com/docs/esw/api_reference/#info
   MovesenseDeviceInfo? get deviceInfo => _deviceInfo;
 
-  /// The battery level of the device, if known.
-  /// Battery level is updated every 10 minutes when connected.
-  DeviceBatteryLevel? get batteryLevel => _batteryLevel;
+  /// The latest known battery level of the device.
+  /// Battery level can be obtained by calling [getBatteryStatus].
+  DeviceBatteryLevel get batteryLevel => _batteryLevel;
 
-  /// Connect to the Movesense device using the [address] specified.
+  /// Initiate connection to the Movesense device using the [address] specified.
   /// If the address is not set, an exception is thrown.
-  Future<void> connect() async {
+  /// Connection status updates are emitted on the [statusEvents] stream.
+  void connect() {
     if (!canConnect()) {
       throw Exception('Cannot connect to device - address is not set.');
     }
@@ -96,10 +97,12 @@ class MovesenseDevice {
     );
   }
 
-  /// Disconnect from the Movesense device.
-  Future<void> disconnect() async {
+  /// Initiate disconnect from the Movesense device.
+  void disconnect() async {
     if (!isConnected) return;
+    serial = null;
     Mds.disconnect(address!);
+    status = DeviceConnectionStatus.disconnected;
   }
 
   /// Get the detailed info about this Movesense device.
@@ -151,7 +154,7 @@ class MovesenseDevice {
       ((data, statusCode) {
         final dataContent = json.decode(data);
         num batteryState = dataContent["Content"] as num;
-        // Movesense reports "OK" (0) or "LOW" (1) battery state
+        // Movesense reports "OK" (0) or "low" (1) battery state
         _batteryLevel = batteryState == 0
             ? DeviceBatteryLevel.ok
             : DeviceBatteryLevel.low;
@@ -274,7 +277,8 @@ enum MovesenseDeviceType {
 enum DeviceConnectionStatus { disconnected, connecting, connected, error }
 
 /// Enumeration of the battery level of the Movesense device.
-enum DeviceBatteryLevel { low, ok, unknown }
+/// See https://www.movesense.com/docs/esw/api_reference/#systemstates
+enum DeviceBatteryLevel { ok, low, unknown }
 
 /// Enumeration of the type of system state components available on the Movesense device.
 /// See https://www.movesense.com/docs/esw/api_reference/#systemstates

--- a/packages/movesense_plus/pubspec.yaml
+++ b/packages/movesense_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: movesense_plus
 description: "A Flutter package for Movesense sensor integration. Wraps the MDS plugin and provides easy access to Movesense device features and data streams."
-version: 1.1.1
+version: 1.2.0
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/movesense_plus
 
 environment:


### PR DESCRIPTION
## 1.2.0

* connect and disconnect method not async
* update to docs

## 1.1.1

Update of docs to highlight that the `address` format is platform dependent:

* on Android, the address is the Bluetooth MAC address (e.g. `0C:8C:DC:1B:23:BF`).
* on iOS, the address is the UUID of the device (e.g. `00000000-0000-0000-0000-000000000000`).
